### PR TITLE
Hotfix/pie option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OD "od" CACHE INTERNAL "")
 set(QEMU "qemu-system-i386" CACHE INTERNAL "")
 set(QEMUOPT "-m" "32" "-localtime" "-vga" "std" "-fda" CACHE INTERNAL "")
 set(QEMU_DEBUG_OPT "-redir" "tcp:5555:127.0.0.1:1234" "&" CACHE INTERNAL "")
-set(BINOPT "-fleading-underscore" "-m32" "-nostdlib" "-Wl,--oformat=binary" CACHE INTERNAL "")
+set(BINOPT "-fleading-underscore" "-m32" "-nostdlib" "-fno-pie" "-Wl,--oformat=binary" CACHE INTERNAL "")
 
 add_subdirectory(parasol)
 add_subdirectory(objconv)

--- a/golibc/CMakeLists.txt
+++ b/golibc/CMakeLists.txt
@@ -48,7 +48,7 @@ set(go_HEADERS
     stdlib.h
     limits.h)
 
-set(GCC_COVERAGE_COMPILE_FLAGS "-m32" "-nostdlib")
+set(GCC_COVERAGE_COMPILE_FLAGS "-m32" "-nostdlib" "-fno-pie")
 add_definitions(${GCC_COVERAGE_COMPILE_FLAGS})
 
 add_library(go STATIC ${go_STAT_SRCS})


### PR DESCRIPTION
GCCがデフォルトでPIEを使うようになったのだが、自作OS作りには邪魔なのでオプションで無効化する。