### PR TITLE
opennaskの実装をbnfcの生成コードで置き換え(7)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,8 @@ set(nask_parse_SRCS
   mod_rm.hpp
   string_util.cpp
   string_util.hpp
+  label.cpp
+  label.hpp
   bnfc/absyn.cc
   bnfc/absyn.hh
   bnfc/buffer.cc

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -736,7 +736,7 @@ void Driver::processJE(std::vector<TParaToken>& mnemonic_args) {
     log()->debug("type: {}, value: {}", type(arg), arg.AsString());
     std::string label = arg.AsString();
 
-    if (LabelJmp::dst_is_stored(label)) {
+    if (LabelJmp::dst_is_stored(label, label_dst_list)) {
         LabelJmp::update_label_src_offset(label, label_dst_list, 0x74, binout_container);
     } else {
         LabelJmp::store_label_src(label, label_src_list, binout_container);
@@ -753,7 +753,7 @@ void Driver::processJMP(std::vector<TParaToken>& mnemonic_args) {
     log()->debug("type: {}, value: {}", type(arg), arg.AsString());
     std::string label = arg.AsString();
 
-    if (LabelJmp::dst_is_stored(label)) {
+    if (LabelJmp::dst_is_stored(label, label_dst_list)) {
         LabelJmp::update_label_src_offset(label, label_dst_list, 0xeb, binout_container);
     } else {
         LabelJmp::store_label_src(label, label_src_list, binout_container);
@@ -850,7 +850,7 @@ void Driver::processMOV(std::vector<TParaToken>& mnemonic_args) {
 
             if (std::get<1>(operands) == TParaToken::ttLabel) {
                 // immがラベルだった場合は後でオフセットを計算する
-                if (LabelJmp::dst_is_stored(dst)) {
+                if (LabelJmp::dst_is_stored(dst, label_dst_list)) {
                     LabelJmp::update_label_src_offset(dst, label_dst_list, opcode, binout_container);
                 } else {
                     LabelJmp::store_label_src(dst, label_src_list, binout_container);
@@ -872,7 +872,7 @@ void Driver::processMOV(std::vector<TParaToken>& mnemonic_args) {
 
             if (std::get<1>(operands) == TParaToken::ttLabel) {
                 // immがラベルだった場合は後でオフセットを計算する
-                if (LabelJmp::dst_is_stored(dst)) {
+                if (LabelJmp::dst_is_stored(dst, label_dst_list)) {
                     LabelJmp::update_label_src_offset(dst, label_dst_list, opcode, binout_container);
                 } else {
                     LabelJmp::store_label_src(dst, label_src_list, binout_container, true, imm16);
@@ -896,7 +896,7 @@ void Driver::processMOV(std::vector<TParaToken>& mnemonic_args) {
 
             if (std::get<1>(operands) == TParaToken::ttLabel) {
                 // immがラベルだった場合は後でオフセットを計算する
-                if (LabelJmp::dst_is_stored(dst)) {
+                if (LabelJmp::dst_is_stored(dst, label_dst_list)) {
                     LabelJmp::update_label_src_offset(dst, label_dst_list, opcode, binout_container);
                 } else {
                     LabelJmp::store_label_src(dst, label_src_list, binout_container, true, imm32);

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -734,23 +734,16 @@ void Driver::processJE(std::vector<TParaToken>& mnemonic_args) {
     auto arg = mnemonic_args[0];
     arg.MustBe(TParaToken::ttIdentifier);
     log()->debug("type: {}, value: {}", type(arg), arg.AsString());
-    binout_container.push_back(0x74);
-    binout_container.push_back(0x00);
-
     std::string label = arg.AsString();
 
-    /**
-    if (label_calc_map.count(label) > 0) {
-        // ラベルのoffset計算が必要
-        LabelCalc l = label_calc_map[label];
-        l.dst_index = this->binout_container.size();
-        const size_t offset = l.get_offset();
-        log()->debug("offset: {} := {} - {}", offset, l.dst_index, l.src_index);
-        binout_container[l.src_index - 1] = offset;
+    if (LabelJmp::dst_is_stored(label)) {
+        LabelJmp::update_label_src_offset(label, label_dst_list, 0x74, binout_container);
     } else {
-        //LabelCalc* label_calc = &LabelCalc{label: label, src_index: binout_container.size()};
-        //label_calc_map[label] = label_calc->clone();
-    }*/
+        LabelJmp::store_label_src(label, label_src_list, binout_container);
+        binout_container.push_back(0x74);
+        binout_container.push_back(0x00);
+        log()->debug("bin[{}] = 0xeb, bin[{}] = 0x00", binout_container.size() - 1, binout_container.size());
+    }
 }
 
 void Driver::processJMP(std::vector<TParaToken>& mnemonic_args) {
@@ -758,22 +751,16 @@ void Driver::processJMP(std::vector<TParaToken>& mnemonic_args) {
     auto arg = mnemonic_args[0];
     arg.MustBe(TParaToken::ttIdentifier);
     log()->debug("type: {}, value: {}", type(arg), arg.AsString());
-    binout_container.push_back(0xeb);
-    binout_container.push_back(0x00);
-
     std::string label = arg.AsString();
-    /**
-    if (label_calc_map.count(label) > 0) {
-		// ラベルのoffset計算が必要
-	    auto l = label_calc_map[label];
-		l.src_index = this->binout_container.size();
-		const int offset = l.get_offset();
-		log()->debug("offset: {} := {} - {}", offset, l.dst_index, l.src_index);
-		binout_container[l.src_index - 1] = offset;
-	} else {
-    	//auto label_calc = LabelCalc{label: label, src_index: binout_container.size()};
-		//label_calc_map[label] = label_calc;
-    }*/
+
+    if (LabelJmp::dst_is_stored(label)) {
+        LabelJmp::update_label_src_offset(label, label_dst_list, 0xeb, binout_container);
+    } else {
+        LabelJmp::store_label_src(label, label_src_list, binout_container);
+        binout_container.push_back(0xeb);
+        binout_container.push_back(0x00);
+        log()->debug("bin[{}] = 0xeb, bin[{}] = 0x00", binout_container.size() - 1, binout_container.size());
+    }
 }
 
 void Driver::processMOV(std::vector<TParaToken>& mnemonic_args) {

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -34,9 +34,11 @@ Driver::~Driver() {
     //    Delete<Program>(parse_tree);
     //}
 
-    //label_calc_map.clear();
-    //binout_container.clear();
-    //binout_container.shrink_to_fit();
+    // メモリの開放
+    label_dst_list.clear();
+    label_dst_list.shrink_to_fit();
+    label_src_list.clear();
+    label_src_list.shrink_to_fit();
 };
 
 LabelDstList Driver::label_dst_list = LabelDstList{};
@@ -1093,18 +1095,11 @@ void Driver::visitLabel(Label x) {
     log()->debug("label='{}' binout_container[{}]",
                  label, std::to_string(this->binout_container.size()));
 
-    /**
-    if (label_calc_map.count(label) > 0) {
-        // ラベルのoffset計算が必要
-        auto l = label_calc_map[label];
-        l.dst_index = this->binout_container.size();
-        const int offset = l.get_offset();
-        log()->debug("offset: {} := {} - {}", offset, l.dst_index, l.src_index);
-        binout_container[l.src_index - 1] = offset;
-    } else {
-        auto label_calc = LabelCalc{label: label, dst_index: static_cast<int>(binout_container.size())};
-        label_calc_map.emplace(label, label_calc);
-    }*/
+    // label: (label_dstと呼ぶ)
+    // 1) label_dstの位置を記録する → label_dst_list
+    // 2) 同名のlabel_srcが保存されていれば、オフセット値を計算して終了
+    LabelJmp::store_label_dst(label, label_dst_list, binout_container);
+    LabelJmp::update_label_dst_offset(label, label_src_list, dollar_position, binout_container);
 
     TParaToken t = TParaToken(x, TParaToken::ttIdentifier);
     this->ctx.push(t);

--- a/src/driver.hh
+++ b/src/driver.hh
@@ -17,10 +17,10 @@
 
 struct LabelCalc {
     std::string label;   // ex) entry
-    size_t src_index;
-    size_t dst_index;
+    int src_index;
+    int dst_index;
 
-    size_t get_offset() {
+    int get_offset() {
         return dst_index - src_index;
     };
 };
@@ -77,21 +77,23 @@ public:
     void visitLabelStmt(LabelStmt *label_stmt) override;
     void visitDeclareStmt(DeclareStmt *declare_stmt) override;
     void visitMnemonicStmt(MnemonicStmt *mnemonic_stmt) override;
+    void visitOpcodeStmt(OpcodeStmt *opcode_stmt) override;
     void visitListMnemonicArgs(ListMnemonicArgs *list_mnemonic_args) override;
     void visitMnemoArg(MnemoArg *mnemo_arg) override;
 
-    // opcodeの読み取り
-    void visitOpcodesADD(OpcodesADD *opcodes_add) override;
-    void visitOpcodesCMP(OpcodesCMP *opcodes_cmp) override;
-    void visitOpcodesDB(OpcodesDB *opcodes_db) override;
-    void visitOpcodesDW(OpcodesDW *opcodes_dw) override;
-    void visitOpcodesDD(OpcodesDD *opcodes_dd) override;
-    void visitOpcodesINT(OpcodesINT *opcodes_int) override;
-    void visitOpcodesJE(OpcodesJE *opcodes_je) override;
-    void visitOpcodesJMP(OpcodesJMP *opcodes_jmp) override;
-    void visitOpcodesMOV(OpcodesMOV *opcodes_mov) override;
-    void visitOpcodesORG(OpcodesORG *opcodes_org) override;
-    void visitOpcodesRESB(OpcodesRESB *opcodes_resb) override;
+    // opcodeの読み取り(空の実装)
+    void visitOpcodesADD(OpcodesADD *opcodes_add) override {};
+    void visitOpcodesCMP(OpcodesCMP *opcodes_cmp) override {};
+    void visitOpcodesDB(OpcodesDB *opcodes_db) override {};
+    void visitOpcodesDW(OpcodesDW *opcodes_dw) override {};
+    void visitOpcodesDD(OpcodesDD *opcodes_dd) override {};
+    void visitOpcodesHLT(OpcodesHLT *opcodes_hlt) override {};
+    void visitOpcodesINT(OpcodesINT *opcodes_int) override {};
+    void visitOpcodesJE(OpcodesJE *opcodes_je) override {};
+    void visitOpcodesJMP(OpcodesJMP *opcodes_jmp) override {};
+    void visitOpcodesMOV(OpcodesMOV *opcodes_mov) override {};
+    void visitOpcodesORG(OpcodesORG *opcodes_org) override {};
+    void visitOpcodesRESB(OpcodesRESB *opcodes_resb) override {};
 
     // opcodeの処理
     void processADD(std::vector<TParaToken>& memonic_args);
@@ -99,6 +101,7 @@ public:
     void processDB(std::vector<TParaToken>& memonic_args);
     void processDW(std::vector<TParaToken>& memonic_args);
     void processDD(std::vector<TParaToken>& memonic_args);
+    void processHLT();
     void processINT(std::vector<TParaToken>& memonic_args);
     void processJE(std::vector<TParaToken>& memonic_args);
     void processJMP(std::vector<TParaToken>& memonic_args);

--- a/src/driver.hh
+++ b/src/driver.hh
@@ -13,17 +13,10 @@
 #include "parsererror.hh"
 #include "nask_defs.hpp"
 #include "skeleton.hh"
+#include "label.hpp"
 
 
-struct LabelCalc {
-    std::string label;   // ex) entry
-    int src_index;
-    int dst_index;
 
-    int get_offset() {
-        return dst_index - src_index;
-    };
-};
 
 class Driver : public Skeleton {
 
@@ -36,8 +29,6 @@ private:
     bool trace_scanning;
     // EQUで設定された変数情報
     static std::map<std::string, std::string> equ_map;
-    // ラベルによるオフセットの計算をする
-    static std::map<std::string, LabelCalc> label_calc_map;
     // $ の位置
     uint32_t dollar_position = 0;
 
@@ -46,6 +37,9 @@ public:
     std::stack<TParaToken> ctx;
     // 出力するバイナリ情報
     std::vector<uint8_t> binout_container;
+    // ラベルによるオフセットの計算をする
+    static LabelDstList label_dst_list;
+    static LabelSrcList label_src_list;
 
     Driver(bool trace_scanning, bool trace_parsing);
 
@@ -53,8 +47,6 @@ public:
     template <class T, class IN>
     int Parse(IN input, const char* assembly_dst);
 
-    // 構文木
-    //std::any m_parse_tree;
     // ASTを評価し結果をファイルに書き込む
     template <class T>
     int Eval(T* parse_tree, const char* assembly_dst);

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -100,11 +100,11 @@ namespace LabelJmp {
         return it != std::end(label_dst_list);
     }
 
-    void store_label_src(std::string label_src,
-                         LabelSrcList& label_src_list,
-                         std::vector<uint8_t>& binout_container,
-                         bool abs,
-                         size_t offset_size) {
+    void store_label_src(std::string label_src,                  // ラベル
+                         LabelSrcList& label_src_list,           // 処理対象ラベルのリスト
+                         std::vector<uint8_t>& binout_container, // 出力するバイナリ
+                         bool abs,                               // オフセットを絶対位置で計算するか
+                         size_t offset_size) {                   // オフセットのサイズ(imm8/imm16/imm32)
 
         LabelSrcElement elem;
         elem.abs = abs;

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -100,6 +100,45 @@ namespace LabelJmp {
         return it != std::end(label_dst_list);
     }
 
+    void store_label_src(std::string label_src,
+                         LabelSrcList& label_src_list,
+                         std::vector<uint8_t>& binout_container,
+                         bool abs,
+                         size_t offset_size) {
+
+        LabelSrcElement elem;
+        elem.abs = abs;
+        elem.offset_size = offset_size;
+        elem.label = label_src;
+        elem.src_index = binout_container.size();
+        elem.rel_index = binout_container.size() + 1;
+        label_src_list.push_back(elem);
+    }
+
+    void update_label_src_offset(std::string label_src,
+                                 LabelDstList& label_dst_list,
+                                 uint8_t nim,
+                                 std::vector<uint8_t>& binout_container) {
+
+        auto it = std::find_if(std::begin(label_dst_list), std::end(label_dst_list),
+                               [&](const LabelDstElement& elem)
+                               { return elem.label == label_src; });
+
+        if (it != std::end(label_dst_list)) {
+            LabelDstElement elem(*it);
+            elem.dst_index = binout_container.size();
+            elem.rel_index = binout_container.size() + 1;
+            log()->debug("update_label_src_offset bin[{}] = {}",
+                         std::to_string(elem.rel_index),
+                         elem.rel_offset());
+
+            binout_container.push_back(nim);
+            binout_container.push_back(elem.rel_offset());
+        }
+
+        return;
+    }
+
     // uint16_tで数値を読み取った後uint8_t型にデータを分けて、リトルエンディアンで格納する
     //
     // @param word             格納するWORDサイズのバイナリ
@@ -125,7 +164,6 @@ namespace LabelJmp {
     }
 
     // uint32_tで数値を読み取った後、uint8_t型にデータを分けて、リトルエンディアンで格納する
-    // nask的にはDDは0x00を普通に詰めるらしい（仕様ブレブレすぎだろ…）
     void set_dword_into_binout(const uint32_t& dword,
                                std::vector<uint8_t>& binout_container,
                                size_t start_index) {
@@ -170,47 +208,5 @@ namespace LabelJmp {
         return 0;
     }
 
-    // OPECODE label (label_srcと呼ぶ)
-    // 1) 同名のlabel_dstが保存されていれば、オフセット値を計算して終了
-    //    処理対象があれば true, 処理対象がなければ false
-    bool update_label_src_offset(std::string label_src,
-                                               std::vector<uint8_t>& binout_container,
-                                               uint8_t nim) {
-
-        auto it = std::find_if(std::begin(label_dst_list), std::end(label_dst_list),
-                               [&](const LabelDstElement& elem)
-                               { return elem.label == label_src; });
-
-        if (it != std::end(label_dst_list)) {
-            LabelDstElement elem(*it);
-            elem.dst_index = binout_container.size();
-            elem.rel_index = binout_container.size() + 1;
-            log()->debug("update_label_src_offset bin[{}] = {}",
-                         std::to_string(elem.rel_index),
-                         elem.rel_offset());
-
-            binout_container.push_back(nim);
-            binout_container.push_back(elem.rel_offset());
-            return true;
-        }
-
-        return false;
-    }
-
-    // OPECODE label (label_srcと呼ぶ)
-    // 1) 同名のlabel_dstが保存されていれば、オフセット値を計算して終了
-    //    処理対象があれば true, 処理対象がなければ false
-    bool update_label_src_offset(std::string label_src,
-                                               std::vector<uint8_t>& binout_container) {
-
-        auto it = std::find_if(std::begin(label_dst_list), std::end(label_dst_list),
-                               [&](const LabelDstElement& elem)
-                               { return elem.label == label_src; });
-
-        if (it != std::end(label_dst_list)) {
-            return true;
-        }
-
-        return false;
-    }**/
+    **/
 }

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -92,8 +92,7 @@ namespace LabelJmp {
         }
     }
 
-    bool dst_is_stored(std::string label_src) {
-        LabelDstList label_dst_list = LabelDstList{};
+    bool dst_is_stored(std::string label_src, LabelDstList& label_dst_list) {
         auto it = std::find_if(std::begin(label_dst_list), std::end(label_dst_list),
                                [&](const LabelDstElement& elem)
                                { return elem.label.find(label_src) != std::string::npos; });

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -1,1 +1,230 @@
 #include "label.hpp"
+
+namespace LabelJmp {
+    // label: (label_dstと呼ぶ)
+    // 1) label_dstの位置を記録する → label_dst_list
+    void store_label_dst(
+        std::string label_dst,
+        std::vector<uint8_t>& binout_container
+    ) {
+        log()->debug("stored label: {} bin[{}]", label_dst, binout_container.size());
+        LabelDstElement elem;
+        elem.label = label_dst;
+        elem.src_index = binout_container.size();
+        //label_dst_list.push_back(elem);
+    }
+
+    // label: (label_dstと呼ぶ)
+    // 2) 同名のlabel_srcが保存されていれば、オフセット値を計算して終了
+    void update_label_dst_offset(
+        std::string label_dst,
+        std::vector<uint8_t>& binout_container
+    ) {
+
+        // $ の位置(引数で渡す)
+        uint32_t dollar_position = 0;
+        LabelSrcList label_src_list = LabelSrcList{};
+
+        for (auto it = std::begin(label_src_list); it != std::end(label_src_list); ++it) {
+            // C++って::selectみたいなことできんのかい
+            LabelSrcElement elem(*it);
+            //log()->debug("update target: {}, stored info {}", label_dst, elem.label);
+            if (elem.label != label_dst)
+                continue;
+
+            // 処理の開始
+            elem.dst_index = binout_container.size();
+            if (elem.abs) {
+                // ORGからの絶対値でオフセットを設定する
+                switch (elem.offset_size) {
+                case imm32:
+                    log()->debug("imm32: update_label_dst_offset bin[{}, {}, {}, {}] = 0x{:02x}",
+                                 elem.rel_index,
+                                 elem.rel_index + 1,
+                                 elem.rel_index + 2,
+                                 elem.rel_index + 3,
+                                 dollar_position + elem.dst_index);
+
+                    set_dword_into_binout(dollar_position + elem.dst_index,
+                                          binout_container, elem.rel_index);
+                    break;
+
+                case imm16:
+                    log()->debug("imm16: update_label_dst_offset bin[{}, {}] = 0x{:02x}",
+                                 elem.rel_index,
+                                 elem.rel_index + 1,
+                                 dollar_position + elem.dst_index);
+
+                    set_word_into_binout(dollar_position + elem.dst_index,
+                                         binout_container, elem.rel_index);
+                    break;
+
+                case imm8:
+                default:
+                    log()->debug("imm8: update_label_dst_offset bin[{}] = {}, bin[{}] = {}",
+                                 elem.rel_index - 1, elem.dst_index, elem.rel_index, 0x7c);
+                    binout_container[elem.rel_index - 1] = elem.dst_index;
+                    binout_container[elem.rel_index] = 0x7c;
+                    break;
+                }
+            } else {
+                // ラベルからの相対値でオフセットを設定する
+                switch (elem.offset_size) {
+                case imm16:
+                    log()->debug("imm16: update_label_dst_offset bin[{}, {}] = 0x{:02x}",
+                                 std::to_string(elem.rel_index),
+                                 std::to_string(elem.rel_index + 1),
+                                 elem.rel_offset() - 1);
+
+                    set_word_into_binout(elem.rel_offset() - 1,
+                                         binout_container,
+                                         elem.rel_index);
+                    break;
+
+                case imm32:
+                    log()->debug("imm32: update_label_dst_offset bin[{}, {}, {}, {}] = 0x{:02x}",
+                                 std::to_string(elem.rel_index),
+                                 std::to_string(elem.rel_index + 1),
+                                 std::to_string(elem.rel_index + 2),
+                                 std::to_string(elem.rel_index + 3),
+                                 elem.rel_offset());
+
+                    set_dword_into_binout(elem.rel_offset(),
+                                          binout_container,
+                                          elem.rel_index);
+                    break;
+
+                case imm8:
+                default:
+                    log()->debug("imm8: update_label_dst_offset bin[{}] = 0x{:02x}",
+                                 std::to_string(elem.rel_index + 1),
+                                 elem.rel_offset());
+                    binout_container[elem.rel_index] = elem.rel_offset();
+                    break;
+                }
+            }
+        }
+    }
+
+    bool dst_is_stored(std::string label_src) {
+        LabelDstList label_dst_list = LabelDstList{};
+        auto it = std::find_if(std::begin(label_dst_list), std::end(label_dst_list),
+                               [&](const LabelDstElement& elem)
+                               { return elem.label.find(label_src) != std::string::npos; });
+        return it != std::end(label_dst_list);
+    }
+
+    // uint16_tで数値を読み取った後uint8_t型にデータを分けて、リトルエンディアンで格納する
+    //
+    // @param word             格納するWORDサイズのバイナリ
+    // @param binout_container 出力先コンテナ
+    // @param start_index      格納するコンテナの開始index
+    //
+    void set_word_into_binout(const uint16_t& word,
+                              std::vector<uint8_t>& binout_container,
+                              size_t start_index) {
+
+        // push_back as little_endian
+        const uint8_t first_byte  = (word >> 8) & 0xff;
+        const uint8_t second_byte = word & 0xff;
+
+        if (start_index == 0) {
+            binout_container.push_back(second_byte);
+            binout_container.push_back(first_byte);
+        } else {
+            binout_container.at(start_index + 0) = second_byte;
+            binout_container.at(start_index + 1) = first_byte;
+        }
+        log()->debug("(W): 0x{:02x}, 0x{:02x}", second_byte, first_byte);
+    }
+
+    // uint32_tで数値を読み取った後、uint8_t型にデータを分けて、リトルエンディアンで格納する
+    // nask的にはDDは0x00を普通に詰めるらしい（仕様ブレブレすぎだろ…）
+    void set_dword_into_binout(const uint32_t& dword,
+                               std::vector<uint8_t>& binout_container,
+                               size_t start_index) {
+
+        uint32_t cp_dword = dword;
+        uint8_t bytes[4] = {};
+
+        bytes[0] = (cp_dword >> 24) & 0xff;
+        bytes[1] = (cp_dword >> 16) & 0xff;
+        bytes[2] = (cp_dword >> 8)  & 0xff;
+        bytes[3] = cp_dword & 0xff;
+
+        if (start_index == 0) {
+            binout_container.push_back(bytes[3]);
+            binout_container.push_back(bytes[2]);
+            binout_container.push_back(bytes[1]);
+            binout_container.push_back(bytes[0]);
+        } else {
+            binout_container.at(start_index + 0) = bytes[3];
+            binout_container.at(start_index + 1) = bytes[2];
+            binout_container.at(start_index + 2) = bytes[1];
+            binout_container.at(start_index + 3) = bytes[0];
+        }
+        log()->debug("(DW): 0x{:02x}, 0x{:02x}, 0x{:02x}, 0x{:02x}",
+                     bytes[3], bytes[2], bytes[1], bytes[0]);
+    }
+
+    /**
+    const long get_label_src_offset(std::string label_src) {
+
+        auto it = std::find_if(std::begin(label_dst_list), std::end(label_dst_list),
+                               [&](const LabelDstElement& elem)
+                               { return elem.label == label_src; });
+
+        if (it != std::end(label_dst_list)) {
+            LabelDstElement elem(*it);
+            log()->debug("matched label: {} with {}", elem.label, label_src);
+            const long abs_size = elem.src_index + dollar_position;
+            return abs_size;
+        }
+
+        return 0;
+    }
+
+    // OPECODE label (label_srcと呼ぶ)
+    // 1) 同名のlabel_dstが保存されていれば、オフセット値を計算して終了
+    //    処理対象があれば true, 処理対象がなければ false
+    bool update_label_src_offset(std::string label_src,
+                                               std::vector<uint8_t>& binout_container,
+                                               uint8_t nim) {
+
+        auto it = std::find_if(std::begin(label_dst_list), std::end(label_dst_list),
+                               [&](const LabelDstElement& elem)
+                               { return elem.label == label_src; });
+
+        if (it != std::end(label_dst_list)) {
+            LabelDstElement elem(*it);
+            elem.dst_index = binout_container.size();
+            elem.rel_index = binout_container.size() + 1;
+            log()->debug("update_label_src_offset bin[{}] = {}",
+                         std::to_string(elem.rel_index),
+                         elem.rel_offset());
+
+            binout_container.push_back(nim);
+            binout_container.push_back(elem.rel_offset());
+            return true;
+        }
+
+        return false;
+    }
+
+    // OPECODE label (label_srcと呼ぶ)
+    // 1) 同名のlabel_dstが保存されていれば、オフセット値を計算して終了
+    //    処理対象があれば true, 処理対象がなければ false
+    bool update_label_src_offset(std::string label_src,
+                                               std::vector<uint8_t>& binout_container) {
+
+        auto it = std::find_if(std::begin(label_dst_list), std::end(label_dst_list),
+                               [&](const LabelDstElement& elem)
+                               { return elem.label == label_src; });
+
+        if (it != std::end(label_dst_list)) {
+            return true;
+        }
+
+        return false;
+    }**/
+}

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -1,0 +1,1 @@
+#include "label.hpp"

--- a/src/label.hpp
+++ b/src/label.hpp
@@ -47,8 +47,8 @@ typedef std::vector<LabelSrcElement> LabelSrcList;
 
 namespace LabelJmp {
     // ":"がついたラベルがジャンプ先(dst)を扱う関数
-    void store_label_dst(std::string label_dst, std::vector<uint8_t>& binout_container);
-    void update_label_dst_offset(std::string label_dst, std::vector<uint8_t>& binout_container);
+    void store_label_dst(std::string, LabelDstList&, std::vector<uint8_t>&);
+    void update_label_dst_offset(std::string, LabelSrcList&, uint32_t, std::vector<uint8_t>&);
     bool dst_is_stored(std::string label_dst);
 
     void set_word_into_binout(const uint16_t& word,

--- a/src/label.hpp
+++ b/src/label.hpp
@@ -1,0 +1,42 @@
+#ifndef LABEL_HPP
+#define LABEL_HPP
+
+#include <iostream>
+#include "spdlog/spdlog.h"
+#include "nask_defs.hpp"
+
+struct LabelDstElement {
+    std::string label; // ex) entry:
+    long src_index;  // JMPのオペコードが始まる場所
+    long dst_index;  // JMPの飛び先のラベルが始まる場所
+    long rel_index;  // rel_offsetを格納する場所
+    long rel_offset() {
+        // offset = rel - dst
+        log()->debug("dst_offs: {} - {} - 1",
+                     std::to_string(src_index), std::to_string(rel_index));
+        return src_index - rel_index - 1;
+    };
+};
+
+struct LabelSrcElement {
+    std::string label;   // ex) entry
+    //OPERAND_KINDS operand;
+    bool abs = false;
+    long src_index;  // JMPのオペコードが始まる場所
+    long dst_index;  // JMPの飛び先のラベルが始まる場所
+    long rel_index;  // rel_offsetを格納する場所
+    size_t offset_size; // オフセットの格納サイズを指定する
+    long rel_offset() {
+        // offset = rel - dst
+        log()->debug("src_offs: {} - {} - 1",
+                     std::to_string(dst_index), std::to_string(rel_index));
+        return dst_index - rel_index - 1;
+    };
+};
+
+// 処理の中でlabel情報の収集をする
+typedef std::vector<LabelDstElement> LabelDstList;
+typedef std::vector<LabelSrcElement> LabelSrcList;
+
+
+#endif // ! LABEL_HPP

--- a/src/label.hpp
+++ b/src/label.hpp
@@ -5,11 +5,17 @@
 #include "spdlog/spdlog.h"
 #include "nask_defs.hpp"
 
+// 名付け的にsource, destinationが逆な気もしたが
+// gotoでジャンプするときをイメージした際に;
+// ":"がついたラベルがジャンプ先(dst)
+// ":"がついてないラベルがジャンプ元(src)
+// と考えてこの命名
+
 struct LabelDstElement {
     std::string label; // ex) entry:
-    long src_index;  // JMPのオペコードが始まる場所
-    long dst_index;  // JMPの飛び先のラベルが始まる場所
-    long rel_index;  // rel_offsetを格納する場所
+    long src_index;    // JMPのオペコードが始まる場所
+    long dst_index;    // JMPの飛び先のラベルが始まる場所
+    long rel_index;    // rel_offsetを格納する場所
     long rel_offset() {
         // offset = rel - dst
         log()->debug("dst_offs: {} - {} - 1",
@@ -21,11 +27,11 @@ struct LabelDstElement {
 struct LabelSrcElement {
     std::string label;   // ex) entry
     //OPERAND_KINDS operand;
-    bool abs = false;
-    long src_index;  // JMPのオペコードが始まる場所
-    long dst_index;  // JMPの飛び先のラベルが始まる場所
-    long rel_index;  // rel_offsetを格納する場所
-    size_t offset_size; // オフセットの格納サイズを指定する
+    bool abs = false;    // オフセットの計算時に相対ではなく絶対位置の場合true
+    long src_index;      // JMPのオペコードが始まる場所
+    long dst_index;      // JMPの飛び先のラベルが始まる場所
+    long rel_index;      // rel_offsetを格納する場所
+    size_t offset_size;  // オフセットの格納サイズを指定する
     long rel_offset() {
         // offset = rel - dst
         log()->debug("src_offs: {} - {} - 1",
@@ -38,5 +44,25 @@ struct LabelSrcElement {
 typedef std::vector<LabelDstElement> LabelDstList;
 typedef std::vector<LabelSrcElement> LabelSrcList;
 
+
+namespace LabelJmp {
+    // ":"がついたラベルがジャンプ先(dst)を扱う関数
+    void store_label_dst(std::string label_dst, std::vector<uint8_t>& binout_container);
+    void update_label_dst_offset(std::string label_dst, std::vector<uint8_t>& binout_container);
+    bool dst_is_stored(std::string label_dst);
+
+    void set_word_into_binout(const uint16_t& word,
+                              std::vector<uint8_t>& binout_container,
+                              size_t start_index = 0);
+    void set_dword_into_binout(const uint32_t& dword,
+                               std::vector<uint8_t>& binout_container,
+                               size_t start_index = 0);
+
+    // ":"がついてないラベルがジャンプ元(src)を扱う関数
+    //void store_label_src(std::string label_src,std::vector<uint8_t>& binout_container, bool abs = false, size_t offset_size = imm8);
+    //const long get_label_src_offset(std::string label_src); // DB, DW, DD用
+    //bool update_label_src_offset(std::string label_src, std::vector<uint8_t>& binout_container, uint8_t nim);
+    //bool update_label_src_offset(std::string label_src, std::vector<uint8_t>& binout_container);
+};
 
 #endif // ! LABEL_HPP

--- a/src/label.hpp
+++ b/src/label.hpp
@@ -51,18 +51,12 @@ namespace LabelJmp {
     void update_label_dst_offset(std::string, LabelSrcList&, uint32_t, std::vector<uint8_t>&);
     bool dst_is_stored(std::string label_dst);
 
-    void set_word_into_binout(const uint16_t& word,
-                              std::vector<uint8_t>& binout_container,
-                              size_t start_index = 0);
-    void set_dword_into_binout(const uint32_t& dword,
-                               std::vector<uint8_t>& binout_container,
-                               size_t start_index = 0);
-
     // ":"がついてないラベルがジャンプ元(src)を扱う関数
-    //void store_label_src(std::string label_src,std::vector<uint8_t>& binout_container, bool abs = false, size_t offset_size = imm8);
-    //const long get_label_src_offset(std::string label_src); // DB, DW, DD用
-    //bool update_label_src_offset(std::string label_src, std::vector<uint8_t>& binout_container, uint8_t nim);
-    //bool update_label_src_offset(std::string label_src, std::vector<uint8_t>& binout_container);
+    void store_label_src(std::string, LabelSrcList& ,std::vector<uint8_t>&, bool abs = false, size_t offset_size = imm8);
+    void update_label_src_offset(std::string, LabelDstList&, uint8_t, std::vector<uint8_t>&);
+
+    void set_word_into_binout(const uint16_t&, std::vector<uint8_t>&, size_t start_index = 0);
+    void set_dword_into_binout(const uint32_t&, std::vector<uint8_t>&, size_t start_index = 0);
 };
 
 #endif // ! LABEL_HPP

--- a/src/label.hpp
+++ b/src/label.hpp
@@ -49,7 +49,7 @@ namespace LabelJmp {
     // ":"がついたラベルがジャンプ先(dst)を扱う関数
     void store_label_dst(std::string, LabelDstList&, std::vector<uint8_t>&);
     void update_label_dst_offset(std::string, LabelSrcList&, uint32_t, std::vector<uint8_t>&);
-    bool dst_is_stored(std::string label_dst);
+    bool dst_is_stored(std::string label_dst, LabelDstList&);
 
     // ":"がついてないラベルがジャンプ元(src)を扱う関数
     void store_label_src(std::string, LabelSrcList& ,std::vector<uint8_t>&, bool abs = false, size_t offset_size = imm8);

--- a/src/para_token.cc
+++ b/src/para_token.cc
@@ -49,10 +49,10 @@ void TParaToken::SetAttribute() {
         _attr = TIdentiferAttribute::ttReg32;
     } else if (std::regex_match(_token_string, segment_registers)) {
         _attr = TIdentiferAttribute::ttSegReg;
-    } else if (IsIdentifier()) {
-        _attr = TIdentiferAttribute::ttRel;
     } else if (IsImmediate()) {
-        _attr = TIdentiferAttribute::ttImm;
+        _attr = TIdentiferAttribute::ttImm; // 即値
+    } else if (IsIdentifier()) {
+        _attr = TIdentiferAttribute::ttLabel; // レジスタ以外のidentなのでラベルと判定
     } else {
         _attr = TIdentiferAttribute::ttAttrUnknown;
     }

--- a/src/para_token.hh
+++ b/src/para_token.hh
@@ -57,7 +57,7 @@ public:
         ttMem,
         ttAcc,
         ttImm,
-        ttRel,
+        ttLabel,
         ttAttrUnknown,
     };
 
@@ -70,7 +70,7 @@ public:
         "ttMem",
         "ttAcc",
         "ttImm",
-        "ttRel",
+        "ttLabel",
         "ttAttrUnknown",
     };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,8 @@ set(parsertest_SRCS
   ../src/demangle.cpp
   ../src/para_token.cc
   ../src/mod_rm.cpp
-  ../src/string_util.cpp)
+  ../src/string_util.cpp
+  ../src/label.cpp)
 
 add_executable(parsertest ${parsertest_SRCS})
 target_link_libraries(parsertest Threads::Threads ${CPPUTEST_LIBRARY})
@@ -79,7 +80,8 @@ set(day01test_SRCS
   ../src/demangle.cpp
   ../src/para_token.cc
   ../src/mod_rm.cpp
-  ../src/string_util.cpp)
+  ../src/string_util.cpp
+  ../src/label.cpp)
 
 add_executable(day01test ${day01test_SRCS} ${BACKWARD_ENABLE})
 target_link_libraries(day01test Threads::Threads ${CPPUTEST_LIBRARY})
@@ -108,7 +110,8 @@ set(day02test_SRCS
   ../src/demangle.cpp
   ../src/para_token.cc
   ../src/mod_rm.cpp
-  ../src/string_util.cpp)
+  ../src/string_util.cpp
+  ../src/label.cpp)
 
 add_executable(day02test ${day02test_SRCS} ${BACKWARD_ENABLE})
 target_link_libraries(day02test Threads::Threads ${CPPUTEST_LIBRARY})

--- a/test/day02test.cpp
+++ b/test/day02test.cpp
@@ -53,7 +53,7 @@ entry:
 		MOV		DS,AX
 		MOV		ES,AX
 
-		;MOV		SI,msg
+		MOV		SI,msg
 putloop:
 		MOV		AL,[SI]
 		ADD		SI,1			; SIに1を足す

--- a/test/day02test.cpp
+++ b/test/day02test.cpp
@@ -62,9 +62,9 @@ putloop:
 		MOV		AH,0x0e			; 一文字表示ファンクション
 		MOV		BX,15			; カラーコード
 		INT		0x10			; ビデオBIOS呼び出し
-		;JMP		putloop
-;fin:
-		;HLT						; 何かあるまでCPUを停止させる
+		JMP		putloop
+fin:
+		HLT						; 何かあるまでCPUを停止させる
 		;JMP		fin				; 無限ループ
 
 ;msg:
@@ -85,10 +85,7 @@ putloop:
 		;RESB	1469432
 )";
 
-    //Driver* d = new Driver(false, false);
-    //delete d;
-
-    std::unique_ptr<Driver> d(new Driver(false, false));
+    std::unique_ptr<Driver> d(new Driver(true, true));
     d->Parse<Program>(nask_statements, "test.img");
 
     std::vector<uint8_t> expected = {};
@@ -128,7 +125,8 @@ putloop:
     expected.insert(expected.end(), {0xb4, 0x0e});
     expected.insert(expected.end(), {0xbb, 0x0f, 0x00});
     expected.insert(expected.end(), {0xcd, 0x10});
-    //expected.insert(expected.end(), {0xeb, 0xee});
+    expected.insert(expected.end(), {0xeb, 0xee});
+    expected.insert(expected.end(), {0xf4});
 
 
     CHECK_EQUAL(expected.size(), d->binout_container.size());

--- a/test/day02test.cpp
+++ b/test/day02test.cpp
@@ -65,24 +65,24 @@ putloop:
 		JMP		putloop
 fin:
 		HLT						; 何かあるまでCPUを停止させる
-		;JMP		fin				; 無限ループ
+		JMP		fin				; 無限ループ
 
-;msg:
-		;DB		0x0a, 0x0a		; 改行を2つ
-		;DB		"hello, world"
-		;DB		0x0a			; 改行
-		;DB		0
+msg:
+		DB		0x0a, 0x0a		; 改行を2つ
+		DB		"hello, world"
+		DB		0x0a			; 改行
+		DB		0
 
-		;RESB	0x7dfe-$		; 0x7dfeまでを0x00で埋める命令
+		RESB	0x7dfe-$		; 0x7dfeまでを0x00で埋める命令
 
-		;DB		0x55, 0xaa
+		DB		0x55, 0xaa
 
 ; 以下はブートセクタ以外の部分の記述
 
-		;DB		0xf0, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00
-		;RESB	4600
-		;DB		0xf0, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00
-		;RESB	1469432
+		DB		0xf0, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00
+		RESB	4600
+		DB		0xf0, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00
+		RESB	1469432
 )";
 
     std::unique_ptr<Driver> d(new Driver(true, true));
@@ -90,6 +90,9 @@ fin:
 
     std::vector<uint8_t> expected = {};
     std::vector<uint8_t> resb18(18, 0);
+    std::vector<uint8_t> resb381(381, 0);
+	std::vector<uint8_t> resb4600(4600, 0);
+    std::vector<uint8_t> resb1469432(1469432, 0);
 
     expected.insert(expected.end(), {0xeb, 0x4e});
     expected.insert(expected.end(), {0x90});
@@ -127,7 +130,19 @@ fin:
     expected.insert(expected.end(), {0xcd, 0x10});
     expected.insert(expected.end(), {0xeb, 0xee});
     expected.insert(expected.end(), {0xf4});
+    expected.insert(expected.end(), {0xeb, 0xfd});
 
+    expected.insert(expected.end(), {0x0a, 0x0a});
+    expected.insert(expected.end(), {0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64});
+    expected.insert(expected.end(), {0x0a});
+    expected.insert(expected.end(), {0x00});
+    expected.insert(expected.end(), std::begin(resb381), std::end(resb381));
+
+    expected.insert(expected.end(), {0x55, 0xaa});
+    expected.insert(expected.end(), {0xf0, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00});
+    expected.insert(expected.end(), std::begin(resb4600), std::end(resb4600));
+    expected.insert(expected.end(), {0xf0, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00});
+    expected.insert(expected.end(), std::begin(resb1469432), std::end(resb1469432));
 
     CHECK_EQUAL(expected.size(), d->binout_container.size());
     //CHECK_TRUE(std::equal(expected.begin(), expected.end(), d->binout_container.begin()));

--- a/test/day02test.cpp
+++ b/test/day02test.cpp
@@ -90,10 +90,11 @@ msg:
 
     std::vector<uint8_t> expected = {};
     std::vector<uint8_t> resb18(18, 0);
-    std::vector<uint8_t> resb381(381, 0);
+    std::vector<uint8_t> resb378(378, 0);
 	std::vector<uint8_t> resb4600(4600, 0);
     std::vector<uint8_t> resb1469432(1469432, 0);
 
+    // 以下は標準的なFAT12フォーマットフロッピーディスクのための記述
     expected.insert(expected.end(), {0xeb, 0x4e});
     expected.insert(expected.end(), {0x90});
     expected.insert(expected.end(), {0x48, 0x45, 0x4c, 0x4c, 0x4f, 0x49, 0x50, 0x4c});
@@ -115,16 +116,17 @@ msg:
     expected.insert(expected.end(), {0x46, 0x41, 0x54, 0x31, 0x32, 0x20, 0x20, 0x20});
 	expected.insert(expected.end(), std::begin(resb18), std::end(resb18));
 
+    // プログラム本体
     expected.insert(expected.end(), {0xb8, 0x00, 0x00});
     expected.insert(expected.end(), {0x8e, 0xd0});
     expected.insert(expected.end(), {0xbc, 0x00, 0x7c});
     expected.insert(expected.end(), {0x8e, 0xd8});
     expected.insert(expected.end(), {0x8e, 0xc0});
-
+    expected.insert(expected.end(), {0xbe, 0x74, 0x7c});
     expected.insert(expected.end(), {0x8a, 0x04});
     expected.insert(expected.end(), {0x83, 0xc6, 0x01});
     expected.insert(expected.end(), {0x3c, 0x00});
-    expected.insert(expected.end(), {0x74, 0x00});
+    expected.insert(expected.end(), {0x74, 0x09});
     expected.insert(expected.end(), {0xb4, 0x0e});
     expected.insert(expected.end(), {0xbb, 0x0f, 0x00});
     expected.insert(expected.end(), {0xcd, 0x10});
@@ -136,7 +138,7 @@ msg:
     expected.insert(expected.end(), {0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64});
     expected.insert(expected.end(), {0x0a});
     expected.insert(expected.end(), {0x00});
-    expected.insert(expected.end(), std::begin(resb381), std::end(resb381));
+    expected.insert(expected.end(), std::begin(resb378), std::end(resb378));
 
     expected.insert(expected.end(), {0x55, 0xaa});
     expected.insert(expected.end(), {0xf0, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00});
@@ -145,7 +147,7 @@ msg:
     expected.insert(expected.end(), std::begin(resb1469432), std::end(resb1469432));
 
     CHECK_EQUAL(expected.size(), d->binout_container.size());
-    //CHECK_TRUE(std::equal(expected.begin(), expected.end(), d->binout_container.begin()));
+    CHECK_TRUE(std::equal(expected.begin(), expected.end(), d->binout_container.begin()));
 }
 
 int main(int argc, char** argv) {

--- a/test/day02test.cpp
+++ b/test/day02test.cpp
@@ -85,6 +85,7 @@ msg:
 		RESB	1469432
 )";
 
+    // od形式で出力する際は `od -t x1 test/test.img > test_img.txt`
     std::unique_ptr<Driver> d(new Driver(true, true));
     d->Parse<Program>(nask_statements, "test.img");
 


### PR DESCRIPTION
ref #32 

## 対応内容
- ２日目の実装とテスト追加
  - [２日目のアセンブラをダンプ](https://github.com/HobbyOSs/opennask/wiki/%EF%BC%92%E6%97%A5%E7%9B%AE%E3%81%AE%E3%82%A2%E3%82%BB%E3%83%B3%E3%83%96%E3%83%A9%E3%82%92%E3%83%80%E3%83%B3%E3%83%97)
- メモリリーク問題は解決できた。ラベル系のオフセット計算にミスがあった。
- 後はリファクタリング等をしつついい感じにしている
  - `LabelJmp` という名前空間を作ってそこにLabel系の処理を押し込んだ
  - パターンマッチを使ったり、不要処理を削除している
  - ラベルのオフセット計算は最初に作った時も難しかったが、流石に２回目なので慣れてきた