### PR TITLE
opennaskの実装をbnfcの生成コードで置き換え(8)

### DIFF
--- a/src/driver.cc
+++ b/src/driver.cc
@@ -466,9 +466,11 @@ void Driver::visitMnemonicStmt(MnemonicStmt *mnemonic_stmt){
         std::make_pair("OpcodesDW", std::bind(&Driver::processDW, this, _1)),
         std::make_pair("OpcodesDD", std::bind(&Driver::processDD, this, _1)),
         std::make_pair("OpcodesINT", std::bind(&Driver::processINT, this, _1)),
+        std::make_pair("OpcodesJAE", std::bind(&Driver::processJAE, this, _1)),
         std::make_pair("OpcodesJC", std::bind(&Driver::processJC, this, _1)),
         std::make_pair("OpcodesJE", std::bind(&Driver::processJE, this, _1)),
         std::make_pair("OpcodesJMP", std::bind(&Driver::processJMP, this, _1)),
+        std::make_pair("OpcodesJNC", std::bind(&Driver::processJNC, this, _1)),
         std::make_pair("OpcodesMOV", std::bind(&Driver::processMOV, this, _1)),
         std::make_pair("OpcodesORG", std::bind(&Driver::processORG, this, _1)),
         std::make_pair("OpcodesRESB", std::bind(&Driver::processRESB, this, _1)),
@@ -480,7 +482,7 @@ void Driver::visitMnemonicStmt(MnemonicStmt *mnemonic_stmt){
     if (it != funcs.end()) {
         it->second(mnemonic_args);
     } else {
-        std::cout << "not implemented..." << std::endl;
+        throw std::runtime_error(opcode + " is not implemented!!!");
     }
 }
 
@@ -502,7 +504,7 @@ void Driver::visitOpcodeStmt(OpcodeStmt *opcode_stmt) {
     if (it != funcs.end()) {
         it->second();
     } else {
-        std::cout << "not implemented..." << std::endl;
+        throw std::runtime_error(opcode + " is not implemented!!!");
     }
 }
 
@@ -573,7 +575,8 @@ void Driver::processADD(std::vector<TParaToken>& mnemonic_args) {
         // 0x03 /r		ADD r32, r/m32		r/m32をr32に加算する
 
         pattern | _ = [&] {
-            log()->debug("Not implemented or not matched..."); return std::vector<uint8_t>();
+            throw std::runtime_error("ADD, Not implemented or not matched!!!");
+            return std::vector<uint8_t>();
         }
     );
 
@@ -624,10 +627,41 @@ void Driver::processCMP(std::vector<TParaToken>& mnemonic_args) {
 		},
 
         // 0x80 /7 ib	CMP r/m8, imm8		imm8をr/m8と比較します
-        // 0x81 /7 iw	CMP r/m16, imm16	imm16をr/m16と比較します
-        // 0x80 /7 id	CMP r/m32, imm32	imm32をr/m32と比較します
+        // 0x81 /7 iw	CMP r/m16, imm16	imm16をr/m16と比較します <-- ?
+        // 0x80 /7 id	CMP r/m32, imm32	imm32をr/m32と比較します <-- ?
         // 0x83 /7 ib	CMP r/m16, imm8		imm8をr/m16と比較します
         // 0x83 /7 ib	CMP r/m32, imm8		imm8をr/m32と比較します
+        pattern | ds(_, TParaToken::ttReg8, TParaToken::ttImm) = [&] {
+
+            const std::string src = mnemonic_args[0].AsString();
+            const uint8_t base = 0x80;
+            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG, src, ModRM::SLASH_7);
+            std::vector<uint8_t> b = {base, modrm};
+            auto imm = mnemonic_args[1].AsUInt8t();
+            std::copy(imm.begin(), imm.end(), std::back_inserter(b));
+            return b;
+        },
+        pattern | ds(_, TParaToken::ttReg16, TParaToken::ttImm) = [&] {
+
+            const std::string src = mnemonic_args[0].AsString();
+            const uint8_t base = 0x83;
+            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG, src, ModRM::SLASH_7);
+            std::vector<uint8_t> b = {base, modrm};
+            auto imm = mnemonic_args[1].AsUInt8t();
+            std::copy(imm.begin(), imm.end(), std::back_inserter(b));
+            return b;
+        },
+        pattern | ds(_, TParaToken::ttReg32, TParaToken::ttImm) = [&] {
+
+            const std::string src = mnemonic_args[0].AsString();
+            const uint8_t base = 0x83;
+            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG, src, ModRM::SLASH_7);
+            std::vector<uint8_t> b = {base, modrm};
+            auto imm = mnemonic_args[1].AsUInt8t();
+            std::copy(imm.begin(), imm.end(), std::back_inserter(b));
+            return b;
+        },
+
         // 0x38 /r		CMP r/m8, r8		r8をr/m8と比較します
         // 0x39 /r		CMP r/m16, r16		r16をr/m16と比較します
         // 0x39 /r		CMP r/m32, r32		r32をr/m32と比較します
@@ -636,7 +670,8 @@ void Driver::processCMP(std::vector<TParaToken>& mnemonic_args) {
         // 0x3B /r		CMP r32, r/m32		r/m32をr32と比較します
 
         pattern | _ = [&] {
-            log()->debug("Not implemented or not matched..."); return std::vector<uint8_t>();
+            throw std::runtime_error("CMP, Not implemented or not matched!!!");
+            return std::vector<uint8_t>();
         }
     );
 
@@ -724,6 +759,23 @@ void Driver::processINT(std::vector<TParaToken>& mnemonic_args) {
     binout_container.push_back(arg.AsInt());
 }
 
+void Driver::processJAE(std::vector<TParaToken>& mnemonic_args) {
+
+    auto arg = mnemonic_args[0];
+    arg.MustBe(TParaToken::ttIdentifier);
+    log()->debug("type: {}, value: {}", type(arg), arg.AsString());
+    std::string label = arg.AsString();
+
+    if (LabelJmp::dst_is_stored(label, label_dst_list)) {
+        LabelJmp::update_label_src_offset(label, label_dst_list, 0x73, binout_container);
+    } else {
+        LabelJmp::store_label_src(label, label_src_list, binout_container);
+        binout_container.push_back(0x73);
+        binout_container.push_back(0x00);
+        log()->debug("bin[{}] = 0x73, bin[{}] = 0x00", binout_container.size() - 1, binout_container.size());
+    }
+}
+
 void Driver::processJC(std::vector<TParaToken>& mnemonic_args) {
 
     auto arg = mnemonic_args[0];
@@ -737,7 +789,7 @@ void Driver::processJC(std::vector<TParaToken>& mnemonic_args) {
         LabelJmp::store_label_src(label, label_src_list, binout_container);
         binout_container.push_back(0x72);
         binout_container.push_back(0x00);
-        log()->debug("bin[{}] = 0xeb, bin[{}] = 0x00", binout_container.size() - 1, binout_container.size());
+        log()->debug("bin[{}] = 0x72, bin[{}] = 0x00", binout_container.size() - 1, binout_container.size());
     }
 }
 
@@ -754,7 +806,7 @@ void Driver::processJE(std::vector<TParaToken>& mnemonic_args) {
         LabelJmp::store_label_src(label, label_src_list, binout_container);
         binout_container.push_back(0x74);
         binout_container.push_back(0x00);
-        log()->debug("bin[{}] = 0xeb, bin[{}] = 0x00", binout_container.size() - 1, binout_container.size());
+        log()->debug("bin[{}] = 0x74, bin[{}] = 0x00", binout_container.size() - 1, binout_container.size());
     }
 }
 
@@ -772,6 +824,23 @@ void Driver::processJMP(std::vector<TParaToken>& mnemonic_args) {
         binout_container.push_back(0xeb);
         binout_container.push_back(0x00);
         log()->debug("bin[{}] = 0xeb, bin[{}] = 0x00", binout_container.size() - 1, binout_container.size());
+    }
+}
+
+void Driver::processJNC(std::vector<TParaToken>& mnemonic_args) {
+
+    auto arg = mnemonic_args[0];
+    arg.MustBe(TParaToken::ttIdentifier);
+    log()->debug("type: {}, value: {}", type(arg), arg.AsString());
+    std::string label = arg.AsString();
+
+    if (LabelJmp::dst_is_stored(label, label_dst_list)) {
+        LabelJmp::update_label_src_offset(label, label_dst_list, 0x73, binout_container);
+    } else {
+        LabelJmp::store_label_src(label, label_src_list, binout_container);
+        binout_container.push_back(0x73);
+        binout_container.push_back(0x00);
+        log()->debug("bin[{}] = 0x73, bin[{}] = 0x00", binout_container.size() - 1, binout_container.size());
     }
 }
 
@@ -929,7 +998,8 @@ void Driver::processMOV(std::vector<TParaToken>& mnemonic_args) {
         //         0xC7 /0	MOV r/m32  , imm32
         // REX.W + 0xC7 /0	MOV r/m64  , imm64
         pattern | _ = [&] {
-            log()->debug("Not implemented or not matched..."); return std::vector<uint8_t>();
+            throw std::runtime_error("MOV, Not implemented or not matched!!!");
+            return std::vector<uint8_t>();
         }
     );
 

--- a/src/driver.hh
+++ b/src/driver.hh
@@ -81,6 +81,7 @@ public:
     void visitOpcodesDD(OpcodesDD *opcodes_dd) override {};
     void visitOpcodesHLT(OpcodesHLT *opcodes_hlt) override {};
     void visitOpcodesINT(OpcodesINT *opcodes_int) override {};
+    void visitOpcodesJC(OpcodesJC *opcodes_jc) override {};
     void visitOpcodesJE(OpcodesJE *opcodes_je) override {};
     void visitOpcodesJMP(OpcodesJMP *opcodes_jmp) override {};
     void visitOpcodesMOV(OpcodesMOV *opcodes_mov) override {};
@@ -95,6 +96,7 @@ public:
     void processDD(std::vector<TParaToken>& memonic_args);
     void processHLT();
     void processINT(std::vector<TParaToken>& memonic_args);
+    void processJC(std::vector<TParaToken>& memonic_args);
     void processJE(std::vector<TParaToken>& memonic_args);
     void processJMP(std::vector<TParaToken>& memonic_args);
     void processMOV(std::vector<TParaToken>& memonic_args);

--- a/src/driver.hh
+++ b/src/driver.hh
@@ -81,8 +81,10 @@ public:
     void visitOpcodesDD(OpcodesDD *opcodes_dd) override {};
     void visitOpcodesHLT(OpcodesHLT *opcodes_hlt) override {};
     void visitOpcodesINT(OpcodesINT *opcodes_int) override {};
+    void visitOpcodesJAE(OpcodesJAE *opcodes_jae) override {};
     void visitOpcodesJC(OpcodesJC *opcodes_jc) override {};
     void visitOpcodesJE(OpcodesJE *opcodes_je) override {};
+    void visitOpcodesJNC(OpcodesJNC *opcodes_jnc) override {};
     void visitOpcodesJMP(OpcodesJMP *opcodes_jmp) override {};
     void visitOpcodesMOV(OpcodesMOV *opcodes_mov) override {};
     void visitOpcodesORG(OpcodesORG *opcodes_org) override {};
@@ -96,8 +98,10 @@ public:
     void processDD(std::vector<TParaToken>& memonic_args);
     void processHLT();
     void processINT(std::vector<TParaToken>& memonic_args);
+    void processJAE(std::vector<TParaToken>& memonic_args);
     void processJC(std::vector<TParaToken>& memonic_args);
     void processJE(std::vector<TParaToken>& memonic_args);
+    void processJNC(std::vector<TParaToken>& memonic_args);
     void processJMP(std::vector<TParaToken>& memonic_args);
     void processMOV(std::vector<TParaToken>& memonic_args);
     void processORG(std::vector<TParaToken>& memonic_args);

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -190,22 +190,4 @@ namespace LabelJmp {
                      bytes[3], bytes[2], bytes[1], bytes[0]);
     }
 
-    /**
-    const long get_label_src_offset(std::string label_src) {
-
-        auto it = std::find_if(std::begin(label_dst_list), std::end(label_dst_list),
-                               [&](const LabelDstElement& elem)
-                               { return elem.label == label_src; });
-
-        if (it != std::end(label_dst_list)) {
-            LabelDstElement elem(*it);
-            log()->debug("matched label: {} with {}", elem.label, label_src);
-            const long abs_size = elem.src_index + dollar_position;
-            return abs_size;
-        }
-
-        return 0;
-    }
-
-    **/
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -127,6 +127,36 @@ add_test(
 
 set_tests_properties(day02test PROPERTIES ATTACHED_FILES_ON_FAIL 0)
 
+# `ctest -R day03`
+set(day03test_SRCS
+  day03test.cpp
+  ../src/bnfc/skeleton.cc
+  ../src/bnfc/absyn.cc
+  ../src/bnfc/parser.cc
+  ../src/bnfc/printer.cc
+  ../src/bnfc/lexer.cc
+  ../src/bnfc/buffer.cc
+  ../src/driver.cc
+  ../src/demangle.cpp
+  ../src/para_token.cc
+  ../src/mod_rm.cpp
+  ../src/string_util.cpp
+  ../src/label.cpp)
+
+add_executable(day03test ${day03test_SRCS} ${BACKWARD_ENABLE})
+target_link_libraries(day03test Threads::Threads ${CPPUTEST_LIBRARY})
+add_backward(day03test)
+
+set_property(TARGET day03test PROPERTY CXX_STANDARD 17)
+set_property(TARGET day03test PROPERTY CXX_STANDARD_REQUIRED ON)
+
+add_test(
+  NAME day03test
+  COMMAND $<TARGET_FILE:day03test>
+)
+
+set_tests_properties(day03test PROPERTIES ATTACHED_FILES_ON_FAIL 0)
+
 # `ctest -R day04`
 set(day04test_SRCS
     day04test.cpp

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -115,14 +115,14 @@ msg:
     expected.insert(expected.end(), {0x40, 0x0b});
     expected.insert(expected.end(), {0xf0});
     expected.insert(expected.end(), {0x09, 0x00});
-	expected.insert(expected.end(), {0x12, 0x00});
-	expected.insert(expected.end(), {0x02, 0x00});
-	expected.insert(expected.end(), {0x00, 0x00, 0x00, 0x00});
-	expected.insert(expected.end(), {0x40, 0x0b, 0x00, 0x00});
-	expected.insert(expected.end(), {0x00, 0x00, 0x29});
-	expected.insert(expected.end(), {0xff, 0xff, 0xff, 0xff});
-	expected.insert(expected.end(), {0x48, 0x41, 0x52, 0x49, 0x42, 0x4f, 0x54, 0x45, 0x4f, 0x53, 0x20});
-	expected.insert(expected.end(), {0x46, 0x41, 0x54, 0x31, 0x32, 0x20, 0x20, 0x20});
+    expected.insert(expected.end(), {0x12, 0x00});
+    expected.insert(expected.end(), {0x02, 0x00});
+    expected.insert(expected.end(), {0x00, 0x00, 0x00, 0x00});
+    expected.insert(expected.end(), {0x40, 0x0b, 0x00, 0x00});
+    expected.insert(expected.end(), {0x00, 0x00, 0x29});
+    expected.insert(expected.end(), {0xff, 0xff, 0xff, 0xff});
+    expected.insert(expected.end(), {0x48, 0x41, 0x52, 0x49, 0x42, 0x4f, 0x54, 0x45, 0x4f, 0x53, 0x20});
+    expected.insert(expected.end(), {0x46, 0x41, 0x54, 0x31, 0x32, 0x20, 0x20, 0x20});
     expected.insert(expected.end(), std::begin(resb18), std::end(resb18));
 
     // プログラム本体
@@ -138,15 +138,15 @@ msg:
     expected.insert(expected.end(), {0xb1, 0x02});
 
     expected.insert(expected.end(), {0xb4, 0x02});
-	expected.insert(expected.end(), {0xb0, 0x01});
-	expected.insert(expected.end(), {0xbb, 0x00, 0x00});
-	expected.insert(expected.end(), {0xb2, 0x00});
+    expected.insert(expected.end(), {0xb0, 0x01});
+    expected.insert(expected.end(), {0xbb, 0x00, 0x00});
+    expected.insert(expected.end(), {0xb2, 0x00});
     expected.insert(expected.end(), {0xcd, 0x13});
     expected.insert(expected.end(), {0x72, 0x03});
     // 読み終わったけどとりあえずやることないので寝る
     expected.insert(expected.end(), {0xf4});
     expected.insert(expected.end(), {0xeb, 0xfd});
-    expected.insert(expected.end(), {0xbe, 0x8a, 0x7c}); // TODO
+    expected.insert(expected.end(), {0xbe, 0x8a, 0x7c});
     expected.insert(expected.end(), {0x8a, 0x04});
     expected.insert(expected.end(), {0x83, 0xc6, 0x01});
     expected.insert(expected.end(), {0x3c, 0x00});
@@ -168,12 +168,183 @@ msg:
     CHECK_TRUE(std::equal(expected.begin(), expected.end(), d->binout_container.begin()));
 }
 
+TEST(day03_suite, harib00b) {
+
+    const char nask_statements[] = R"(
+; haribote-ipl
+; TAB=4
+
+		ORG		0x7c00			; このプログラムがどこに読み込まれるのか
+
+; 以下は標準的なFAT12フォーマットフロッピーディスクのための記述
+
+		JMP		entry
+		DB		0x90
+		DB		"HARIBOTE"		; ブートセクタの名前を自由に書いてよい（8バイト）
+		DW		512				; 1セクタの大きさ（512にしなければいけない）
+		DB		1				; クラスタの大きさ（1セクタにしなければいけない）
+		DW		1				; FATがどこから始まるか（普通は1セクタ目からにする）
+		DB		2				; FATの個数（2にしなければいけない）
+		DW		224				; ルートディレクトリ領域の大きさ（普通は224エントリにする）
+		DW		2880			; このドライブの大きさ（2880セクタにしなければいけない）
+		DB		0xf0			; メディアのタイプ（0xf0にしなければいけない）
+		DW		9				; FAT領域の長さ（9セクタにしなければいけない）
+		DW		18				; 1トラックにいくつのセクタがあるか（18にしなければいけない）
+		DW		2				; ヘッドの数（2にしなければいけない）
+		DD		0				; パーティションを使ってないのでここは必ず0
+		DD		2880			; このドライブ大きさをもう一度書く
+		DB		0,0,0x29		; よくわからないけどこの値にしておくといいらしい
+		DD		0xffffffff		; たぶんボリュームシリアル番号
+		DB		"HARIBOTEOS "	; ディスクの名前（11バイト）
+		DB		"FAT12   "		; フォーマットの名前（8バイト）
+		RESB	18				; とりあえず18バイトあけておく
+
+; プログラム本体
+
+entry:
+		MOV		AX,0			; レジスタ初期化
+		MOV		SS,AX
+		MOV		SP,0x7c00
+		MOV		DS,AX
+
+; ディスクを読む
+
+		MOV		AX,0x0820
+		MOV		ES,AX
+		MOV		CH,0			; シリンダ0
+		MOV		DH,0			; ヘッド0
+		MOV		CL,2			; セクタ2
+
+		MOV		SI,0			; 失敗回数を数えるレジスタ
+retry:
+		MOV		AH,0x02			; AH=0x02 : ディスク読み込み
+		MOV		AL,1			; 1セクタ
+		MOV		BX,0
+		MOV		DL,0x00			; Aドライブ
+		INT		0x13			; ディスクBIOS呼び出し
+		JNC		fin				; エラーがおきなければfinへ
+		ADD		SI,1			; SIに1を足す
+		CMP		SI,5			; SIと5を比較
+		JAE		error			; SI >= 5 だったらerrorへ
+		MOV		AH,0x00
+		MOV		DL,0x00			; Aドライブ
+		INT		0x13			; ドライブのリセット
+		JMP		retry
+
+; 読み終わったけどとりあえずやることないので寝る
+
+fin:
+		HLT						; 何かあるまでCPUを停止させる
+		JMP		fin				; 無限ループ
+
+error:
+		MOV		SI,msg
+putloop:
+		MOV		AL,[SI]
+		ADD		SI,1			; SIに1を足す
+		CMP		AL,0
+		JE		fin
+		MOV		AH,0x0e			; 一文字表示ファンクション
+		MOV		BX,15			; カラーコード
+		INT		0x10			; ビデオBIOS呼び出し
+		JMP		putloop
+msg:
+		DB		0x0a, 0x0a		; 改行を2つ
+		DB		"load error"
+		DB		0x0a			; 改行
+		DB		0
+
+		RESB	0x7dfe-$		; 0x7dfeまでを0x00で埋める命令
+
+		DB		0x55, 0xaa
+)";
+
+    // od形式で出力する際は `od -t x1 test/test.img > test_img.txt`
+    std::unique_ptr<Driver> d(new Driver(true, true));
+    d->Parse<Program>(nask_statements, "test.img");
+
+    std::vector<uint8_t> expected = {};
+    std::vector<uint8_t> resb18(18, 0);
+    std::vector<uint8_t> resb339(339, 0);
+
+    // 以下は標準的なFAT12フォーマットフロッピーディスクのための記述
+    expected.insert(expected.end(), {0xeb, 0x4e});
+    expected.insert(expected.end(), {0x90});
+    expected.insert(expected.end(), {0x48, 0x41, 0x52, 0x49, 0x42, 0x4f, 0x54, 0x45});
+    expected.insert(expected.end(), {0x00, 0x02});
+    expected.insert(expected.end(), {0x01});
+    expected.insert(expected.end(), {0x01, 0x00});
+    expected.insert(expected.end(), {0x02});
+    expected.insert(expected.end(), {0xe0, 0x00});
+    expected.insert(expected.end(), {0x40, 0x0b});
+    expected.insert(expected.end(), {0xf0});
+    expected.insert(expected.end(), {0x09, 0x00});
+    expected.insert(expected.end(), {0x12, 0x00});
+    expected.insert(expected.end(), {0x02, 0x00});
+    expected.insert(expected.end(), {0x00, 0x00, 0x00, 0x00});
+    expected.insert(expected.end(), {0x40, 0x0b, 0x00, 0x00});
+    expected.insert(expected.end(), {0x00, 0x00, 0x29});
+    expected.insert(expected.end(), {0xff, 0xff, 0xff, 0xff});
+    expected.insert(expected.end(), {0x48, 0x41, 0x52, 0x49, 0x42, 0x4f, 0x54, 0x45, 0x4f, 0x53, 0x20});
+    expected.insert(expected.end(), {0x46, 0x41, 0x54, 0x31, 0x32, 0x20, 0x20, 0x20});
+    expected.insert(expected.end(), std::begin(resb18), std::end(resb18));
+
+    // プログラム本体
+    expected.insert(expected.end(), {0xb8, 0x00, 0x00});
+    expected.insert(expected.end(), {0x8e, 0xd0});
+    expected.insert(expected.end(), {0xbc, 0x00, 0x7c});
+    expected.insert(expected.end(), {0x8e, 0xd8});
+    // ディスクを読む
+    expected.insert(expected.end(), {0xb8, 0x20, 0x08});
+    expected.insert(expected.end(), {0x8e, 0xc0});
+    expected.insert(expected.end(), {0xb5, 0x00});
+    expected.insert(expected.end(), {0xb6, 0x00});
+    expected.insert(expected.end(), {0xb1, 0x02});
+    expected.insert(expected.end(), {0xbe, 0x00, 0x00});
+
+    expected.insert(expected.end(), {0xb4, 0x02});
+    expected.insert(expected.end(), {0xb0, 0x01});
+    expected.insert(expected.end(), {0xbb, 0x00, 0x00});
+    expected.insert(expected.end(), {0xb2, 0x00});
+    expected.insert(expected.end(), {0xcd, 0x13});
+    expected.insert(expected.end(), {0x73, 0x10});
+    expected.insert(expected.end(), {0x83, 0xc6, 0x01});
+    expected.insert(expected.end(), {0x83, 0xfe, 0x05});
+    expected.insert(expected.end(), {0x73, 0x0b});
+    expected.insert(expected.end(), {0xb4, 0x00});
+    expected.insert(expected.end(), {0xb2, 0x00});
+    expected.insert(expected.end(), {0xcd, 0x13});
+    expected.insert(expected.end(), {0xeb, 0xe3});
+    expected.insert(expected.end(), {0xf4});
+    expected.insert(expected.end(), {0xeb, 0xfd});
+    expected.insert(expected.end(), {0xbe, 0x9d, 0x7c});
+    expected.insert(expected.end(), {0x8a, 0x04});
+    expected.insert(expected.end(), {0x83, 0xc6, 0x01});
+    expected.insert(expected.end(), {0x3c, 0x00});
+    expected.insert(expected.end(), {0x74, 0xf1});
+    expected.insert(expected.end(), {0xb4, 0x0e});
+    expected.insert(expected.end(), {0xbb, 0x0f, 0x00});
+    expected.insert(expected.end(), {0xcd, 0x10});
+    expected.insert(expected.end(), {0xeb, 0xee});
+
+    expected.insert(expected.end(), {0x0a, 0x0a});
+    expected.insert(expected.end(), {0x6c, 0x6f, 0x61, 0x64, 0x20, 0x65, 0x72, 0x72, 0x6f, 0x72});
+
+    expected.insert(expected.end(), {0x0a});
+    expected.insert(expected.end(), {0x00});
+    expected.insert(expected.end(), std::begin(resb339), std::end(resb339));
+    expected.insert(expected.end(), {0x55, 0xaa});
+
+    CHECK_EQUAL(expected.size(), d->binout_container.size());
+    CHECK_TRUE(std::equal(expected.begin(), expected.end(), d->binout_container.begin()));
+}
+
 int main(int argc, char** argv) {
     spdlog::set_level(spdlog::level::debug);
     std::vector<const char*> args(argv, argv + argc); // Insert all arguments
     args.push_back("-v"); // Set verbose mode
     args.push_back("-c"); // Set color output (OPTIONAL)
-    //args.push_back("TEST(day03_suite, helloos2)");
+    //args.push_back("TEST(day03_suite, harib00b)");
 
     // Run all tests
     int i = RUN_ALL_TESTS(args.size(), &args[0]);

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -1,0 +1,181 @@
+#include "driver.hh"
+#include "demangle.hpp"
+#include "tinyexpr.h"
+#include "spdlog/spdlog.h"
+
+#include <CppUTest/TestHarness.h>
+#include <CppUTest/CommandLineTestRunner.h>
+
+auto logger = spdlog::stdout_logger_mt("opennask", "console");
+
+TEST_GROUP(day03_suite)
+{
+
+};
+
+TEST(day03_suite, harib00a) {
+
+    const char nask_statements[] = R"(
+; haribote-ipl
+; TAB=4
+
+		ORG		0x7c00			; このプログラムがどこに読み込まれるのか
+
+; 以下は標準的なFAT12フォーマットフロッピーディスクのための記述
+
+		JMP		entry
+		DB		0x90
+		DB		"HARIBOTE"		; ブートセクタの名前を自由に書いてよい（8バイト）
+		DW		512				; 1セクタの大きさ（512にしなければいけない）
+		DB		1				; クラスタの大きさ（1セクタにしなければいけない）
+		DW		1				; FATがどこから始まるか（普通は1セクタ目からにする）
+		DB		2				; FATの個数（2にしなければいけない）
+		DW		224				; ルートディレクトリ領域の大きさ（普通は224エントリにする）
+		DW		2880			; このドライブの大きさ（2880セクタにしなければいけない）
+		DB		0xf0			; メディアのタイプ（0xf0にしなければいけない）
+		DW		9				; FAT領域の長さ（9セクタにしなければいけない）
+		DW		18				; 1トラックにいくつのセクタがあるか（18にしなければいけない）
+		DW		2				; ヘッドの数（2にしなければいけない）
+		DD		0				; パーティションを使ってないのでここは必ず0
+		DD		2880			; このドライブ大きさをもう一度書く
+		DB		0,0,0x29		; よくわからないけどこの値にしておくといいらしい
+		DD		0xffffffff		; たぶんボリュームシリアル番号
+		DB		"HARIBOTEOS "	; ディスクの名前（11バイト）
+		DB		"FAT12   "		; フォーマットの名前（8バイト）
+		RESB	18				; とりあえず18バイトあけておく
+
+; プログラム本体
+
+entry:
+		MOV		AX,0			; レジスタ初期化
+		MOV		SS,AX
+		MOV		SP,0x7c00
+		MOV		DS,AX
+
+; ディスクを読む
+
+		MOV		AX,0x0820
+		MOV		ES,AX
+		MOV		CH,0			; シリンダ0
+		MOV		DH,0			; ヘッド0
+		MOV		CL,2			; セクタ2
+
+		MOV		AH,0x02			; AH=0x02 : ディスク読み込み
+		MOV		AL,1			; 1セクタ
+		MOV		BX,0
+		MOV		DL,0x00			; Aドライブ
+		INT		0x13			; ディスクBIOS呼び出し
+		JC		error
+
+; 読み終わったけどとりあえずやることないので寝る
+
+fin:
+		HLT						; 何かあるまでCPUを停止させる
+		JMP		fin				; 無限ループ
+
+error:
+		MOV		SI,msg
+putloop:
+		MOV		AL,[SI]
+		ADD		SI,1			; SIに1を足す
+		CMP		AL,0
+		JE		fin
+		MOV		AH,0x0e			; 一文字表示ファンクション
+		MOV		BX,15			; カラーコード
+		INT		0x10			; ビデオBIOS呼び出し
+		JMP		putloop
+msg:
+		DB		0x0a, 0x0a		; 改行を2つ
+		DB		"load error"
+		DB		0x0a			; 改行
+		DB		0
+
+		RESB	0x7dfe-$		; 0x7dfeまでを0x00で埋める命令
+
+		DB		0x55, 0xaa
+)";
+
+    // od形式で出力する際は `od -t x1 test/test.img > test_img.txt`
+    std::unique_ptr<Driver> d(new Driver(true, true));
+    d->Parse<Program>(nask_statements, "test.img");
+
+    std::vector<uint8_t> expected = {};
+    std::vector<uint8_t> resb18(18, 0);
+    std::vector<uint8_t> resb358(358, 0);
+
+    // 以下は標準的なFAT12フォーマットフロッピーディスクのための記述
+    expected.insert(expected.end(), {0xeb, 0x4e});
+    expected.insert(expected.end(), {0x90});
+    expected.insert(expected.end(), {0x48, 0x41, 0x52, 0x49, 0x42, 0x4f, 0x54, 0x45});
+    expected.insert(expected.end(), {0x00, 0x02});
+    expected.insert(expected.end(), {0x01});
+    expected.insert(expected.end(), {0x01, 0x00});
+    expected.insert(expected.end(), {0x02});
+    expected.insert(expected.end(), {0xe0, 0x00});
+    expected.insert(expected.end(), {0x40, 0x0b});
+    expected.insert(expected.end(), {0xf0});
+    expected.insert(expected.end(), {0x09, 0x00});
+	expected.insert(expected.end(), {0x12, 0x00});
+	expected.insert(expected.end(), {0x02, 0x00});
+	expected.insert(expected.end(), {0x00, 0x00, 0x00, 0x00});
+	expected.insert(expected.end(), {0x40, 0x0b, 0x00, 0x00});
+	expected.insert(expected.end(), {0x00, 0x00, 0x29});
+	expected.insert(expected.end(), {0xff, 0xff, 0xff, 0xff});
+	expected.insert(expected.end(), {0x48, 0x41, 0x52, 0x49, 0x42, 0x4f, 0x54, 0x45, 0x4f, 0x53, 0x20});
+	expected.insert(expected.end(), {0x46, 0x41, 0x54, 0x31, 0x32, 0x20, 0x20, 0x20});
+    expected.insert(expected.end(), std::begin(resb18), std::end(resb18));
+
+    // プログラム本体
+    expected.insert(expected.end(), {0xb8, 0x00, 0x00});
+    expected.insert(expected.end(), {0x8e, 0xd0});
+    expected.insert(expected.end(), {0xbc, 0x00, 0x7c});
+    expected.insert(expected.end(), {0x8e, 0xd8});
+    // ディスクを読む
+    expected.insert(expected.end(), {0xb8, 0x20, 0x08});
+    expected.insert(expected.end(), {0x8e, 0xc0});
+    expected.insert(expected.end(), {0xb5, 0x00});
+    expected.insert(expected.end(), {0xb6, 0x00});
+    expected.insert(expected.end(), {0xb1, 0x02});
+
+    expected.insert(expected.end(), {0xb4, 0x02});
+	expected.insert(expected.end(), {0xb0, 0x01});
+	expected.insert(expected.end(), {0xbb, 0x00, 0x00});
+	expected.insert(expected.end(), {0xb2, 0x00});
+    expected.insert(expected.end(), {0xcd, 0x13});
+    expected.insert(expected.end(), {0x72, 0x03});
+    // 読み終わったけどとりあえずやることないので寝る
+    expected.insert(expected.end(), {0xf4});
+    expected.insert(expected.end(), {0xeb, 0xfd});
+    expected.insert(expected.end(), {0xbe, 0x8a, 0x7c}); // TODO
+    expected.insert(expected.end(), {0x8a, 0x04});
+    expected.insert(expected.end(), {0x83, 0xc6, 0x01});
+    expected.insert(expected.end(), {0x3c, 0x00});
+    expected.insert(expected.end(), {0x74, 0xf1});
+    expected.insert(expected.end(), {0xb4, 0x0e});
+    expected.insert(expected.end(), {0xbb, 0x0f, 0x00});
+    expected.insert(expected.end(), {0xcd, 0x10});
+    expected.insert(expected.end(), {0xeb, 0xee});
+
+    expected.insert(expected.end(), {0x0a, 0x0a});
+    expected.insert(expected.end(), {0x6c, 0x6f, 0x61, 0x64, 0x20, 0x65, 0x72, 0x72, 0x6f, 0x72});
+
+    expected.insert(expected.end(), {0x0a});
+    expected.insert(expected.end(), {0x00});
+    expected.insert(expected.end(), std::begin(resb358), std::end(resb358));
+    expected.insert(expected.end(), {0x55, 0xaa});
+
+    CHECK_EQUAL(expected.size(), d->binout_container.size());
+    CHECK_TRUE(std::equal(expected.begin(), expected.end(), d->binout_container.begin()));
+}
+
+int main(int argc, char** argv) {
+    spdlog::set_level(spdlog::level::debug);
+    std::vector<const char*> args(argv, argv + argc); // Insert all arguments
+    args.push_back("-v"); // Set verbose mode
+    args.push_back("-c"); // Set color output (OPTIONAL)
+    //args.push_back("TEST(day03_suite, helloos2)");
+
+    // Run all tests
+    int i = RUN_ALL_TESTS(args.size(), &args[0]);
+    return i;
+}


### PR DESCRIPTION
ref #32 

## 対応内容
- ３日目のテスト追加(harib00a, harib00b)
  - [３日目のアセンブラをダンプ](https://github.com/HobbyOSs/opennask/wiki/%EF%BC%93%E6%97%A5%E7%9B%AE%E3%81%AE%E3%82%A2%E3%82%BB%E3%83%B3%E3%83%96%E3%83%A9%E3%82%92%E3%83%80%E3%83%B3%E3%83%97%EF%BC%88%E5%89%8D%E7%B7%A8%EF%BC%89)
- 未定義のオペコードがあるとデバッグしにくいので、マッチするオペコードが無ければ例外を発生するようにした