### PR TITLE
opennaskの実装をbnfcの生成コードで置き換え(11)

### DIFF
--- a/src/front_end.cc
+++ b/src/front_end.cc
@@ -880,16 +880,39 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
         //         0xC7 /0	MOV r/m32  , imm32
         // REX.W + 0xC7 /0	MOV r/m64  , imm64
         pattern | ds(TParaToken::ttMem8, TParaToken::ttImm) = [&] {
-            throw std::runtime_error("ttMem8!!!");
-            return std::vector<uint8_t>();
+            std::string dst = "[" + mnemonic_args[0].AsString() + "]";
+            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG_REG, dst, ModRM::SLASH_0);
+
+            std::vector<uint8_t> b = {0xc6, modrm};
+            auto addr = mnemonic_args[0].AsUInt16t();
+            std::copy(addr.begin(), addr.end(), std::back_inserter(b));
+            auto imm = mnemonic_args[1].AsUInt8t();
+            std::copy(imm.begin(), imm.end(), std::back_inserter(b));
+            return b;
         },
         pattern | ds(TParaToken::ttMem16, TParaToken::ttImm) = [&] {
-            throw std::runtime_error("ttMem16!!!");
-            return std::vector<uint8_t>();
+            std::string dst = "[" + mnemonic_args[0].AsString() + "]";
+            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG_REG, dst, ModRM::SLASH_0);
+
+            std::vector<uint8_t> b = {0xc7, modrm};
+            auto addr = mnemonic_args[0].AsUInt16t();
+            std::copy(addr.begin(), addr.end(), std::back_inserter(b));
+            auto imm = mnemonic_args[1].AsUInt16t();
+            std::copy(imm.begin(), imm.end(), std::back_inserter(b));
+            return b;
         },
         pattern | ds(TParaToken::ttMem32, TParaToken::ttImm) = [&] {
-            throw std::runtime_error("ttMem32!!!");
-            return std::vector<uint8_t>();
+            std::string dst = "[" + mnemonic_args[0].AsString() + "]";
+            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG_REG, dst, ModRM::SLASH_0);
+
+            // Override prefixes(0x66)
+            // TODO: 16bit命令モードで動作中のみ0x66を付与するようにする
+            std::vector<uint8_t> b = {0x66, 0xc7, modrm};
+            auto addr = mnemonic_args[0].AsUInt16t();
+            std::copy(addr.begin(), addr.end(), std::back_inserter(b));
+            auto imm = mnemonic_args[1].AsUInt32t();
+            std::copy(imm.begin(), imm.end(), std::back_inserter(b));
+            return b;
         },
         pattern | _ = [&] {
             throw std::runtime_error("MOV, Not implemented or not matched!!!");

--- a/src/front_end.hh
+++ b/src/front_end.hh
@@ -102,6 +102,14 @@ public:
     // expression
     void visitImmExp(ImmExp *p) override;
     void visitIndirectAddrExp(IndirectAddrExp *p) override;
+
+    void visitDatatypeExp(DatatypeExp *p) override;
+    void visitByteDataType(ByteDataType *p) override;
+    void visitWordDataType(WordDataType *p) override;
+    void visitDwordDataType(DwordDataType *p) override;
+    template <class T>
+    void visitDataTypes(T *t);
+
     void visitPlusExp(PlusExp *p) override;
     void visitMinusExp(MinusExp *p) override;
     void visitMulExp(MulExp *p) override;
@@ -126,7 +134,7 @@ public:
     void visitLabel(Label x) override;
 
     // 以下、整理後にstring_utilに移動
-    const std::string join(std::vector<TParaToken>& array, const std::string& sep = "");
+    const std::string join(std::vector<std::string>&, const std::string& = "");
     const std::array<uint8_t, 1> IntAsByte(const int);
     const std::array<uint8_t, 2> IntAsWord(const int);
     const std::array<uint8_t, 4> LongAsDword(const long);

--- a/src/para_token.hh
+++ b/src/para_token.hh
@@ -55,12 +55,17 @@ public:
         ttReg64,
         ttSegReg,
         ttMem,
+        ttMem8,
+        ttMem16,
+        ttMem32,
+        ttMem64,
         ttAcc,
         ttImm,
         ttLabel,
         ttAttrUnknown,
     };
 
+    // enumと同様の意味の文字列表現
     static constexpr const char* TIAttributeNames[] = {
         "ttReg8",
         "ttReg16",
@@ -68,6 +73,10 @@ public:
         "ttReg64",
         "ttSegReg",
         "ttMem",
+        "ttMem8",
+        "ttMem16",
+        "ttMem32",
+        "ttMem64",
         "ttAcc",
         "ttImm",
         "ttLabel",

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -987,19 +987,19 @@ VRAM	EQU		0x0ff8			; グラフィックバッファの開始番地
 		MOV		AH,0x00
 		INT		0x10
 		MOV		BYTE [VMODE],8	; 画面モードをメモする
-		;MOV		WORD [SCRNX],320
-		;MOV		WORD [SCRNY],200
-		;MOV		DWORD [VRAM],0x000a0000
+		MOV		WORD [SCRNX],320
+		MOV		WORD [SCRNY],200
+		MOV		DWORD [VRAM],0x000a0000
 
 ; キーボードのLED状態をBIOSに教えてもらう
 
-		;MOV		AH,0x02
-		;INT		0x16 			; keyboard BIOS
-		;MOV		[LEDS],AL
+		MOV		AH,0x02
+		INT		0x16 			; keyboard BIOS
+		MOV		[LEDS],AL
 
 fin:
-		;HLT
-		;JMP		fin
+		HLT
+		JMP		fin
 )";
 
     // od形式で出力する際は `od -t x1 test/test.img > test_img.txt`
@@ -1016,7 +1016,17 @@ fin:
     expected.insert(expected.end(), {0xb0, 0x13});
     expected.insert(expected.end(), {0xb4, 0x00});
     expected.insert(expected.end(), {0xcd, 0x10});
-    expected.insert(expected.end(), {0xc6, 0x06});
+    expected.insert(expected.end(), {0xc6, 0x06, 0xf2, 0x0f, 0x08}); // BYTE [VMODE],8
+    expected.insert(expected.end(), {0xc7, 0x06, 0xf4, 0x0f, 0x40, 0x01}); // WORD [SCRNX],320
+    expected.insert(expected.end(), {0xc7, 0x06, 0xf6, 0x0f, 0xc8, 0x00}); // WORD [SCRNY],200
+    expected.insert(expected.end(), {0x66, 0xc7, 0x06, 0xf8, 0x0f, 0x00, 0x00, 0x0a, 0x00}); // DWORD [VRAM],0x000a0000
+
+    expected.insert(expected.end(), {0xb4, 0x02});
+    expected.insert(expected.end(), {0xcd, 0x16});
+    expected.insert(expected.end(), {0x88, 0x06});
+    expected.insert(expected.end(), {0xf1, 0x0f});
+    expected.insert(expected.end(), {0xf4});
+    expected.insert(expected.end(), {0xeb, 0xfd});
 
     CHECK_EQUAL(expected.size(), d->binout_container.size());
     std::string msg = "[diff]\n" + diff(expected, d->binout_container);

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -986,7 +986,7 @@ VRAM	EQU		0x0ff8			; グラフィックバッファの開始番地
 		MOV		AL,0x13			; VGAグラフィックス、320x200x8bitカラー
 		MOV		AH,0x00
 		INT		0x10
-		;MOV		BYTE [VMODE],8	; 画面モードをメモする
+		MOV		BYTE [VMODE],8	; 画面モードをメモする
 		;MOV		WORD [SCRNX],320
 		;MOV		WORD [SCRNY],200
 		;MOV		DWORD [VRAM],0x000a0000
@@ -1016,6 +1016,7 @@ fin:
     expected.insert(expected.end(), {0xb0, 0x13});
     expected.insert(expected.end(), {0xb4, 0x00});
     expected.insert(expected.end(), {0xcd, 0x10});
+    expected.insert(expected.end(), {0xc6, 0x06});
 
     CHECK_EQUAL(expected.size(), d->binout_container.size());
     std::string msg = "[diff]\n" + diff(expected, d->binout_container);


### PR DESCRIPTION
ref #32 

## 対応内容
- ３日目のテスト追加(harib00h)
  - [３日目のアセンブラをダンプ（後編）](https://github.com/HobbyOSs/opennask/wiki/%EF%BC%93%E6%97%A5%E7%9B%AE%E3%81%AE%E3%82%A2%E3%82%BB%E3%83%B3%E3%83%96%E3%83%A9%E3%82%92%E3%83%80%E3%83%B3%E3%83%97%EF%BC%88%E5%BE%8C%E7%B7%A8%EF%BC%89)
