### PR TITLE
Pass1アセンブラの実装, 必要な機械語のサイズを出力する実装とテスト

### DIFF
--- a/src/front_end.cc
+++ b/src/front_end.cc
@@ -810,7 +810,7 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
         //         0x88 /r	MOV r/m8   , r8
         // REX   + 0x88 /r	MOV r/m8   , r8
         //
-        pattern | ds(TParaToken::ttMem , TParaToken::ttReg8, _ != "AL") = [&] {
+        pattern | ds(or_(TParaToken::ttMem8, TParaToken::ttMem16) , TParaToken::ttReg8, _ != "AL") = [&] {
             const std::string dst_mem = "[" + mnemonic_args[0].AsString() + "]";
             const std::string src_reg = mnemonic_args[1].AsString();
 
@@ -831,7 +831,7 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
         //         0x8B /r	MOV r16    , r/m16
         //         0x8B /r	MOV r32    , r/m32
         // REX.W + 0x8B /r	MOV r64    , r/m64
-        pattern | ds(TParaToken::ttReg8 , TParaToken::ttMem, _) = [&] {
+        pattern | ds(TParaToken::ttReg8 , or_(TParaToken::ttMem8, TParaToken::ttMem16), _) = [&] {
             const std::string src_mem = "[" + mnemonic_args[1].AsString() + "]";
             const std::string dst_reg = mnemonic_args[0].AsString();
 
@@ -840,7 +840,7 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             std::vector<uint8_t> b = {base, modrm};
             return b;
         },
-        pattern | ds(TParaToken::ttReg16, TParaToken::ttMem, _) = [&] {
+        pattern | ds(TParaToken::ttReg16, TParaToken::ttMem16, _) = [&] {
             const std::string src_mem = "[" + mnemonic_args[1].AsString() + "]";
             const std::string dst_reg = mnemonic_args[0].AsString();
 
@@ -849,7 +849,7 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             std::vector<uint8_t> b = {base, modrm};
             return b;
         },
-        pattern | ds(TParaToken::ttReg32, TParaToken::ttMem, _) = [&] {
+        pattern | ds(TParaToken::ttReg32, TParaToken::ttMem32, _) = [&] {
             const std::string src_mem = "[" + mnemonic_args[1].AsString() + "]";
             const std::string dst_reg = mnemonic_args[0].AsString();
 
@@ -894,7 +894,7 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
         //         0xA3	    MOV moffs16, AX
         //		   0xA3		MOV moffs32, EAX
         // REX.W + 0xA3		MOV moffs64, RAX
-        pattern | ds(TParaToken::ttMem, TParaToken::ttReg8, "AL") = [&] {
+        pattern | ds(TParaToken::ttMem16, TParaToken::ttReg8, "AL") = [&] {
 
             const uint8_t base = 0xa2;
             std::vector<uint8_t> b = {base};
@@ -902,7 +902,7 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             std::copy(addr.begin(), addr.end(), std::back_inserter(b));
             return b;
         },
-        pattern | ds(TParaToken::ttMem, TParaToken::ttReg16, "AX") = [&] {
+        pattern | ds(TParaToken::ttMem16, TParaToken::ttReg16, "AX") = [&] {
 
             const uint8_t base = 0xa3;
             std::vector<uint8_t> b = {base};
@@ -910,7 +910,7 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             std::copy(addr.begin(), addr.end(), std::back_inserter(b));
             return b;
         },
-        pattern | ds(TParaToken::ttMem, TParaToken::ttReg32, "EAX") = [&] {
+        pattern | ds(TParaToken::ttMem32, TParaToken::ttReg32, "EAX") = [&] {
 
             const uint8_t base = 0xa3;
             std::vector<uint8_t> b = {base};
@@ -1035,7 +1035,14 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             return b;
         },
         pattern | _ = [&] {
-            throw std::runtime_error("MOV, Not implemented or not matched!!!");
+            std::stringstream ss;
+            ss << "MOV, Not implemented or not matched!!! \n"
+               << TParaToken::TIAttributeNames[mnemonic_args[0].AsAttr()]
+               << ", "
+               << TParaToken::TIAttributeNames[mnemonic_args[1].AsAttr()]
+               << std::endl;
+
+            throw std::runtime_error(ss.str());
             return std::vector<uint8_t>();
         }
     );
@@ -1150,8 +1157,32 @@ void FrontEnd::visitIndirectAddrExp(IndirectAddrExp *indirect_addr_exp) {
         indirect_addr_exp->exp_->accept(this);
     }
     // [SI] のような間接アドレス表現を読み取る
+    std::regex registers8 (R"(AL|BL|CL|DL|AH|BH|CH|DH)");
+    std::regex registers16(R"(AX|BX|CX|DX|SP|DI|BP|SI)");
+    std::regex registers32(R"(EAX|EBX|ECX|EDX|ESP|EDI|EBP|ESI)");
+    std::regex registers64(R"(RAX|RBX|RCX|RDX)");
+
     TParaToken t = this->ctx.top();
-    t.SetAttribute(TParaToken::ttMem); // TODO: 8,16,32,64を判定する
+    if (std::regex_match(t.AsString(), registers8)) {
+        t.SetAttribute(TParaToken::ttMem8);
+    } else if (std::regex_match(t.AsString(), registers16)) {
+        t.SetAttribute(TParaToken::ttMem16);
+    } else if (std::regex_match(t.AsString(), registers32)) {
+        t.SetAttribute(TParaToken::ttMem32);
+    } else if (std::regex_match(t.AsString(), registers64)) {
+      t.SetAttribute(TParaToken::ttMem64);
+    } else if (t.IsHex()) {
+        auto attr = match(static_cast<uint64_t>(t.AsLong()))(
+            pattern | (0U <= _ && _ <= std::numeric_limits<uint8_t>::max())  = TParaToken::ttMem8,
+            pattern | (0U <= _ && _ <= std::numeric_limits<uint16_t>::max()) = TParaToken::ttMem16,
+            pattern | (0U <= _ && _ <= std::numeric_limits<uint32_t>::max()) = TParaToken::ttMem32,
+            pattern | _ = TParaToken::ttMem64
+        );
+        t.SetAttribute(attr);
+    } else {
+        t.SetAttribute(TParaToken::ttMem);
+    }
+
     this->ctx.pop();
     this->ctx.push(t);
 }

--- a/src/front_end.cc
+++ b/src/front_end.cc
@@ -1151,7 +1151,7 @@ void FrontEnd::visitIndirectAddrExp(IndirectAddrExp *indirect_addr_exp) {
     }
     // [SI] のような間接アドレス表現を読み取る
     TParaToken t = this->ctx.top();
-    t.SetAttribute(TParaToken::ttMem);
+    t.SetAttribute(TParaToken::ttMem); // TODO: 8,16,32,64を判定する
     this->ctx.pop();
     this->ctx.push(t);
 }

--- a/src/front_end.hh
+++ b/src/front_end.hh
@@ -29,6 +29,7 @@ private:
     bool trace_scanning;
     // $ の位置
     uint32_t dollar_position = 0;
+    OPENNASK_MODES bit_mode = ID_16BIT_MODE;
 
 public:
     // visitorのcontext情報

--- a/src/nask_parse.cpp
+++ b/src/nask_parse.cpp
@@ -64,6 +64,7 @@ int main (int argc, char *argv[]) {
     std::unique_ptr<FrontEnd> d(new FrontEnd(trace_scanning, trace_parsing));
 
     if (argv[optind+1] != NULL) {
+        // ファイルから読み込む場合
         assembly_src = argv[optind];
         assembly_dst = argv[optind + 1];
 
@@ -79,6 +80,7 @@ int main (int argc, char *argv[]) {
         return d->Eval<Program>(parse_tree.get(), assembly_dst);
     }
 
+    // 標準入力から読み込む場合
     assembly_dst = argv[optind];
     auto parse_tree = d->Parse<Program>(std::cin);
     return d->Eval<Program>(parse_tree.get(), assembly_dst);

--- a/src/para_token.cc
+++ b/src/para_token.cc
@@ -19,14 +19,20 @@ TParaToken::TParaToken(void) {
 }
 
 TParaToken::TParaToken(const string& token_string,
+                       TTokenType type) {
+
+    _token_string = token_string;
+    _type = type;
+    SetAttribute();
+}
+
+TParaToken::TParaToken(const string& token_string,
                        TTokenType type,
                        TIdentiferAttribute attr) {
 
     _token_string = token_string;
     _type = type;
-    if (attr != ttAttrUnknown) {
-        SetAttribute(attr);
-    }
+    SetAttribute(attr);
 }
 
 TParaToken::TParaToken(const TParaToken& token) {

--- a/src/para_token.cc
+++ b/src/para_token.cc
@@ -18,10 +18,15 @@ TParaToken::TParaToken(void) {
     _type = ttEmpty;
 }
 
-TParaToken::TParaToken(const string& token_string, TTokenType type) {
+TParaToken::TParaToken(const string& token_string,
+                       TTokenType type,
+                       TIdentiferAttribute attr) {
+
     _token_string = token_string;
     _type = type;
-    SetAttribute();
+    if (attr != ttAttrUnknown) {
+        SetAttribute(attr);
+    }
 }
 
 TParaToken::TParaToken(const TParaToken& token) {
@@ -47,6 +52,8 @@ void TParaToken::SetAttribute() {
         _attr = TIdentiferAttribute::ttReg16;
     } else if (std::regex_match(_token_string, registers32)) {
         _attr = TIdentiferAttribute::ttReg32;
+    } else if (std::regex_match(_token_string, registers64)) {
+        _attr = TIdentiferAttribute::ttReg64;
     } else if (std::regex_match(_token_string, segment_registers)) {
         _attr = TIdentiferAttribute::ttSegReg;
     } else if (IsImmediate()) {

--- a/src/para_token.hh
+++ b/src/para_token.hh
@@ -86,7 +86,9 @@ public:
 public:
 
     TParaToken(void);
-    TParaToken(const std::string& token_string, TTokenType type);
+    explicit TParaToken(const std::string& token_string,
+                        TTokenType type = ttUnknown,
+                        TIdentiferAttribute attr = ttAttrUnknown);
     TParaToken(const TParaToken& token);
     ~TParaToken();
     void SetAttribute();

--- a/src/para_token.hh
+++ b/src/para_token.hh
@@ -87,8 +87,10 @@ public:
 
     TParaToken(void);
     explicit TParaToken(const std::string& token_string,
-                        TTokenType type = ttUnknown,
-                        TIdentiferAttribute attr = ttAttrUnknown);
+                        TTokenType type);
+    explicit TParaToken(const std::string& token_string,
+                        TTokenType type,
+                        TIdentiferAttribute attr);
     TParaToken(const TParaToken& token);
     ~TParaToken();
     void SetAttribute();

--- a/src/pass1_strategy.cc
+++ b/src/pass1_strategy.cc
@@ -425,76 +425,76 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
 
     uint32_t l = match(operands)(
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttMem8, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttMem16, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg32, "EAX", _, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttMem32, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg64, "RAX", _, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttMem64, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem8, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem64, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(_, _, TParaToken::ttReg32, "EAX") = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(_, _, TParaToken::ttReg64, "RAX") = [&] {
-            return inst.get_output_size(mnemonic_args[0], mnemonic_args[1]);
+            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
         }
     );
 

--- a/src/pass1_strategy.cc
+++ b/src/pass1_strategy.cc
@@ -425,76 +425,76 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
 
     uint32_t l = match(operands)(
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttMem8, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttMem16, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg32, "EAX", _, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttMem32, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg64, "RAX", _, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttMem64, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem8, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem64, _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(TParaToken::ttMem64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(_, _, TParaToken::ttReg32, "EAX") = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         },
         pattern | ds(_, _, TParaToken::ttReg64, "RAX") = [&] {
-            return inst.get_output_size({mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
         }
     );
 

--- a/src/pass1_strategy.cc
+++ b/src/pass1_strategy.cc
@@ -556,8 +556,32 @@ void Pass1Strategy::visitIndirectAddrExp(IndirectAddrExp *indirect_addr_exp) {
         indirect_addr_exp->exp_->accept(this);
     }
     // [SI] のような間接アドレス表現を読み取る
+    std::regex registers8 (R"(AL|BL|CL|DL|AH|BH|CH|DH)");
+    std::regex registers16(R"(AX|BX|CX|DX|SP|DI|BP|SI)");
+    std::regex registers32(R"(EAX|EBX|ECX|EDX|ESP|EDI|EBP|ESI)");
+    std::regex registers64(R"(RAX|RBX|RCX|RDX)");
+
     TParaToken t = this->ctx.top();
-    t.SetAttribute(TParaToken::ttMem);
+    if (std::regex_match(t.AsString(), registers8)) {
+        t.SetAttribute(TParaToken::ttMem8);
+    } else if (std::regex_match(t.AsString(), registers16)) {
+        t.SetAttribute(TParaToken::ttMem16);
+    } else if (std::regex_match(t.AsString(), registers32)) {
+        t.SetAttribute(TParaToken::ttMem32);
+    } else if (std::regex_match(t.AsString(), registers64)) {
+      t.SetAttribute(TParaToken::ttMem64);
+    } else if (t.IsHex()) {
+        auto attr = match(static_cast<uint64_t>(t.AsLong()))(
+            pattern | (0U <= _ && _ <= std::numeric_limits<uint8_t>::max())  = TParaToken::ttMem8,
+            pattern | (0U <= _ && _ <= std::numeric_limits<uint16_t>::max()) = TParaToken::ttMem16,
+            pattern | (0U <= _ && _ <= std::numeric_limits<uint32_t>::max()) = TParaToken::ttMem32,
+            pattern | _ = TParaToken::ttMem64
+        );
+        t.SetAttribute(attr);
+    } else {
+        t.SetAttribute(TParaToken::ttMem);
+    }
+
     this->ctx.pop();
     this->ctx.push(t);
 }

--- a/src/pass1_strategy.hh
+++ b/src/pass1_strategy.hh
@@ -23,6 +23,7 @@ public:
 
     // LOC(location of counter)
     uint32_t loc = 0;
+    OPENNASK_MODES bit_mode = ID_16BIT_MODE;
     // Pass1のシンボルテーブル, リテラルテーブル
     std::map<std::string, uint32_t> sym_table;
     std::map<std::string, uint32_t> lit_table;

--- a/src/x86.cc
+++ b/src/x86.cc
@@ -36,36 +36,21 @@ namespace x86_64 {
       );
     }
 
-    const int Encoding::get_output_size() {
+    const int Encoding::get_output_size(OPENNASK_MODES mode) {
         int output_size = 0;
 
-        if (prefix_) {
-            std::cout << "prefix size: "
-                      << prefix_->get_size()
-                      << std::endl;
+        if (prefix_ && prefix_->mandatory()) {
             output_size += prefix_->get_size();
         }
-        if (rex_) {
-            std::cout << "rex size: "
-                      << rex_->get_size()
-                      << std::endl;
-            output_size += rex_->get_size();
+        if (REX_ && REX_->mandatory()) {
+            output_size += REX_->get_size();
         }
-        if (vex_) {
-            std::cout << "vex size: "
-                      << vex_->get_size()
-                      << std::endl;
-            output_size += vex_->get_size();
+        if (VEX_) {
+            output_size += VEX_->get_size();
         }
-        std::cout << "opcode size: "
-                  << opcode_.get_size()
-                  << std::endl;
         output_size += opcode_.get_size();
-        if (mod_rm_) {
-            std::cout << "modrm size: "
-                      << mod_rm_->get_size()
-                      << std::endl;
-            output_size += mod_rm_->get_size();
+        if (ModRM_) {
+            output_size += ModRM_->get_size();
         }
         if (immediate_) {
             output_size += immediate_->size();
@@ -80,7 +65,7 @@ namespace x86_64 {
         return output_size;
     }
 
-    const uint32_t Instruction::get_output_size(std::initializer_list<TParaToken> tokens) {
+    const uint32_t Instruction::get_output_size(OPENNASK_MODES mode, std::initializer_list<TParaToken> tokens) {
 
         for (int i = 0; i < tokens.size(); i++) {
             std::cout << (tokens.begin() + i)->AsString() << std::endl;
@@ -107,8 +92,6 @@ namespace x86_64 {
                                return detect;
                                });
 
-        std::cout << "starting !!!! " << std::endl;
-
         if (it != forms_.end()) {
             auto& found_form = *it;
             auto encodings = found_form.encodings();
@@ -116,14 +99,13 @@ namespace x86_64 {
             std::cout << "type(found_form) -> " << type(found_form)
                       << " \n"
                       << " ** -> "
-                      << encodings[0].get_output_size()
+                      << encodings[0].get_output_size(mode)
                       << " "
                       << std::endl;
 
-            const uint32_t size = encodings[0].get_output_size();
+            const uint32_t size = encodings[0].get_output_size(mode);
             return size;
         }
-        std::cout << "end !!!! " << std::endl;
 
         return 0;
     }

--- a/src/x86.cc
+++ b/src/x86.cc
@@ -1,5 +1,6 @@
 #include "x86.hh"
 #include "matchit.h"
+#include "demangle.hpp"
 
 using namespace matchit;
 
@@ -13,9 +14,9 @@ namespace x86_64 {
 
     const char* X86_64_JSON = gx86_json_Data;
 
-    const std::string token_to_x86_type(TParaToken& operand) {
+    const std::string token_to_x86_type(const TParaToken* operand) {
 
-      return match(operand.AsAttr())(
+      return match(operand->AsAttr())(
           pattern | TParaToken::ttReg8  = [&] { return "r8"; },
           pattern | TParaToken::ttReg16 = [&] { return "r16"; },
           pattern | TParaToken::ttReg32 = [&] { return "r32"; },
@@ -25,15 +26,105 @@ namespace x86_64 {
           pattern | TParaToken::ttMem32 = [&] { return "m32"; },
           pattern | TParaToken::ttMem64 = [&] { return "m64"; },
           pattern | TParaToken::ttMem64 = [&] { return "m64"; },
-          pattern | TParaToken::ttImm   = [&] { return "imm"; }
+          pattern | TParaToken::ttImm   = [&] { return "imm"; },
+          pattern | _ = [&] {
+              throw std::runtime_error(
+                  operand->to_string() + " Not implemented or not matched!!!"
+              );
+              return "";
+          }
       );
     }
 
-    const uint32_t Instruction::get_output_size(TParaToken& opr1,
-                                                TParaToken& opr2) {
+    const int Encoding::get_output_size() {
+        int output_size = 0;
 
-        token_to_x86_type(opr1);
-        token_to_x86_type(opr2);
+        if (prefix_) {
+            std::cout << "prefix size: "
+                      << prefix_->get_size()
+                      << std::endl;
+            output_size += prefix_->get_size();
+        }
+        if (rex_) {
+            std::cout << "rex size: "
+                      << rex_->get_size()
+                      << std::endl;
+            output_size += rex_->get_size();
+        }
+        if (vex_) {
+            std::cout << "vex size: "
+                      << vex_->get_size()
+                      << std::endl;
+            output_size += vex_->get_size();
+        }
+        std::cout << "opcode size: "
+                  << opcode_.get_size()
+                  << std::endl;
+        output_size += opcode_.get_size();
+        if (mod_rm_) {
+            std::cout << "modrm size: "
+                      << mod_rm_->get_size()
+                      << std::endl;
+            output_size += mod_rm_->get_size();
+        }
+        if (immediate_) {
+            output_size += immediate_->size();
+        }
+        if (data_offset_) {
+            output_size += data_offset_->size();
+        }
+        if (code_offset_) {
+            output_size += code_offset_->size();
+        }
+
+        return output_size;
+    }
+
+    const uint32_t Instruction::get_output_size(std::initializer_list<TParaToken> tokens) {
+
+        for (int i = 0; i < tokens.size(); i++) {
+            std::cout << (tokens.begin() + i)->AsString() << std::endl;
+        }
+
+        auto it = std::find_if(forms_.begin(), forms_.end(),
+                               [&](InstructionForm &form) {
+                               if (!form.operands().has_value()) {
+                                   return false;
+                               }
+
+                               auto operands = form.operands().value();
+                               if (operands.size() != tokens.size()) {
+                                   return false;
+                               }
+
+                               bool detect = true;
+                               for (int i = 0; i < tokens.size(); i++) {
+                                   if ( token_to_x86_type(tokens.begin() + i) != operands[i].type()) {
+                                       detect = false;
+                                       break;
+                                   }
+                               }
+                               return detect;
+                               });
+
+        std::cout << "starting !!!! " << std::endl;
+
+        if (it != forms_.end()) {
+            auto& found_form = *it;
+            auto encodings = found_form.encodings();
+
+            std::cout << "type(found_form) -> " << type(found_form)
+                      << " \n"
+                      << " ** -> "
+                      << encodings[0].get_output_size()
+                      << " "
+                      << std::endl;
+
+            const uint32_t size = encodings[0].get_output_size();
+            return size;
+        }
+        std::cout << "end !!!! " << std::endl;
+
         return 0;
     }
 };

--- a/src/x86.hh
+++ b/src/x86.hh
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <optional>
 #include <jsoncons/json.hpp>
+#include "nask_defs.hpp"
 #include "para_token.hh"
 
 namespace x86_64 {
@@ -96,15 +97,15 @@ namespace x86_64 {
         }
     };
 
-    class REX {
+    class Rex {
         bool mandatory_;
         std::optional<std::string> W_;
         std::optional<std::string> R_;
         std::optional<std::string> B_;
         std::optional<std::string> X_;
     public:
-        REX() {}
-        REX(const bool mandatory,
+        Rex() {}
+        Rex(const bool mandatory,
             const std::optional<std::string>& W,
             const std::optional<std::string>& R,
             const std::optional<std::string>& B,
@@ -139,7 +140,7 @@ namespace x86_64 {
         }
     };
 
-    class VEX {
+    class Vex {
         std::optional<std::string> mmmmm_;
         std::optional<std::string> pp_;
         std::optional<std::string> W_;
@@ -147,8 +148,8 @@ namespace x86_64 {
         std::optional<std::string> R_;
         std::optional<std::string> X_;
     public:
-        VEX() {}
-        VEX(const std::optional<std::string>& mmmmm,
+        Vex() {}
+        Vex(const std::optional<std::string>& mmmmm,
             const std::optional<std::string>& pp,
             const std::optional<std::string>& W,
             const std::optional<std::string>& L,
@@ -199,13 +200,13 @@ namespace x86_64 {
         }
     };
 
-    class ModRM {
+    class Modrm {
         std::string mode_;
         std::string rm_;
         std::string reg_;
     public:
-        ModRM() {}
-        ModRM(const std::string& mode,
+        Modrm() {}
+        Modrm(const std::string& mode,
               const std::string& rm,
               const std::string& reg)
             : mode_(mode), rm_(rm), reg_(reg)
@@ -342,9 +343,9 @@ namespace x86_64 {
     class Encoding {
         Opcode opcode_;
         std::optional<Prefix> prefix_;
-        std::optional<REX> rex_;
-        std::optional<VEX> vex_;
-        std::optional<ModRM> mod_rm_;
+        std::optional<Rex> REX_;
+        std::optional<Vex> VEX_;
+        std::optional<Modrm> ModRM_;
         std::optional<Immediate> immediate_;
         std::optional<DataOffset> data_offset_;
         std::optional<CodeOffset> code_offset_;
@@ -353,17 +354,17 @@ namespace x86_64 {
         Encoding() {}
         Encoding(const Opcode& opcode,
                  const std::optional<Prefix>& prefix,
-                 const std::optional<REX>& rex,
-                 const std::optional<VEX>& vex,
-                 const std::optional<ModRM>& mod_rm,
+                 const std::optional<Rex>& REX,
+                 const std::optional<Vex>& VEX,
+                 const std::optional<Modrm>& ModRM,
                  const std::optional<Immediate>& immediate,
                  const std::optional<DataOffset> data_offset,
                  const std::optional<CodeOffset> code_offset)
             : opcode_(opcode),
               prefix_(prefix),
-              rex_(rex),
-              vex_(vex),
-              mod_rm_(mod_rm),
+              REX_(REX),
+              VEX_(VEX),
+              ModRM_(ModRM),
               immediate_(immediate),
               data_offset_(data_offset),
               code_offset_(code_offset)
@@ -377,17 +378,17 @@ namespace x86_64 {
         {
             return prefix_;
         }
-        const std::optional<REX>& rex() const
+        const std::optional<Rex>& REX() const
         {
-            return rex_;
+            return REX_;
         }
-        const std::optional<VEX>& vex() const
+        const std::optional<Vex>& VEX() const
         {
-            return vex_;
+            return VEX_;
         }
-        const std::optional<ModRM>& mod_rm() const
+        const std::optional<Modrm>& ModRM() const
         {
-            return mod_rm_;
+            return ModRM_;
         }
         const std::optional<Immediate>& immediate() const
         {
@@ -402,7 +403,7 @@ namespace x86_64 {
             return data_offset_;
         }
 
-        const int get_output_size();
+        const int get_output_size(OPENNASK_MODES mode);
     };
 
     class InstructionForm {
@@ -478,7 +479,7 @@ namespace x86_64 {
             return forms_;
         }
 
-        const uint32_t get_output_size(std::initializer_list<TParaToken> tokens);
+        const uint32_t get_output_size(OPENNASK_MODES mode, std::initializer_list<TParaToken> tokens);
     };
 
     class InstructionSet {
@@ -505,16 +506,16 @@ namespace x86_64 {
 
 JSONCONS_ALL_CTOR_GETTER_TRAITS(x86_64::Isa, id)
 JSONCONS_ALL_CTOR_GETTER_TRAITS(x86_64::Prefix, mandatory, byte)
-JSONCONS_N_CTOR_GETTER_TRAITS(x86_64::REX, 1, mandatory, W, R, B, X)
-JSONCONS_N_CTOR_GETTER_TRAITS(x86_64::VEX, 1, mmmmm, pp, W, L, R, X)
-JSONCONS_ALL_CTOR_GETTER_TRAITS(x86_64::ModRM, mode, rm, reg)
+JSONCONS_N_CTOR_GETTER_TRAITS(x86_64::Rex, 1, mandatory, W, R, B, X)
+JSONCONS_N_CTOR_GETTER_TRAITS(x86_64::Vex, 1, mmmmm, pp, W, L, R, X)
+JSONCONS_ALL_CTOR_GETTER_TRAITS(x86_64::Modrm, mode, rm, reg)
 JSONCONS_ALL_CTOR_GETTER_TRAITS(x86_64::ImplicitOperand, id, input, output)
 JSONCONS_N_CTOR_GETTER_TRAITS(x86_64::Operand, 1, type, input, output, extended_size)
 JSONCONS_ALL_CTOR_GETTER_TRAITS(x86_64::DataOffset, size, value)
 JSONCONS_ALL_CTOR_GETTER_TRAITS(x86_64::CodeOffset, size, value)
 JSONCONS_ALL_CTOR_GETTER_TRAITS(x86_64::Immediate, size, value)
 JSONCONS_N_CTOR_GETTER_TRAITS(x86_64::Opcode, 1, byte, addend)
-JSONCONS_N_CTOR_GETTER_TRAITS(x86_64::Encoding, 1, opcode, prefix, rex, vex, mod_rm, immediate, data_offset, code_offset)
+JSONCONS_N_CTOR_GETTER_TRAITS(x86_64::Encoding, 1, opcode, prefix, REX, VEX, ModRM, immediate, data_offset, code_offset)
 JSONCONS_N_CTOR_GETTER_TRAITS(x86_64::InstructionForm, 1, encodings, operands, implicit_operands, xmm_mode, cancelling_inputs, isa)
 JSONCONS_ALL_CTOR_GETTER_TRAITS(x86_64::InstructionSet, instruction_set, instructions)
 JSONCONS_ALL_CTOR_GETTER_TRAITS(x86_64::Instruction, summary, forms)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,7 @@ gtest_discover_tests(modrmtest)
 set(x86_table_test_SRCS
   x86_table_test.cpp
   ../src/x86.cc
+  ../src/demangle.cpp
   ../src/para_token.cc)
 
 add_executable(x86_table_test ${x86_table_test_SRCS})

--- a/test/x86_table_test.cpp
+++ b/test/x86_table_test.cpp
@@ -78,7 +78,7 @@ struct TokenToX86TypeParam {
 };
 
 void PrintTo(const TokenToX86TypeParam& param, ::std::ostream* os) {
-  *os << param.para_token.to_string();
+    *os << param.para_token.to_string();
 }
 
 class TokenToX86Type : public testing::TestWithParam<TokenToX86TypeParam> {

--- a/test/x86_table_test.cpp
+++ b/test/x86_table_test.cpp
@@ -3,6 +3,7 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "x86.hh"
 #include <gtest/gtest.h>
+#include "nask_defs.hpp"
 
 using namespace x86_64;
 using namespace jsoncons;
@@ -115,10 +116,11 @@ TEST_F(X86TableSuite, GetOutputSize)
 
     auto inst = iset.instructions().at("ADD");
     auto size = inst.get_output_size(
+        ID_16BIT_MODE,
         {
             TParaToken("[BX]", TParaToken::ttIdentifier, TParaToken::ttMem16),
             TParaToken("AX", TParaToken::ttIdentifier, TParaToken::ttReg16)
         }
     );
-    EXPECT_EQ(3, size);
+    EXPECT_EQ(2, size);
 }

--- a/test/x86_table_test.cpp
+++ b/test/x86_table_test.cpp
@@ -59,6 +59,51 @@ TEST_F(X86TableSuite, CheckJsonSchema)
     }
 }
 
+// テストデータクラス
+struct TokenToX86TypeParam {
+    const std::string token;
+    const TParaToken para_token;
+    std::string expected;
+
+    TokenToX86TypeParam(
+        const std::string& token,
+        const TParaToken::TIdentiferAttribute attr,
+        std::string expected
+    ):
+        para_token(TParaToken(token, TParaToken::ttUnknown, attr)),
+        expected(expected)
+    {
+    }
+};
+
+void PrintTo(const TokenToX86TypeParam& param, ::std::ostream* os) {
+  *os << param.para_token.to_string();
+}
+
+class TokenToX86Type : public testing::TestWithParam<TokenToX86TypeParam> {
+};
+
+TEST_P(TokenToX86Type, TokenToX86Type) {
+    const auto p = GetParam();
+
+    EXPECT_EQ(token_to_x86_type(&p.para_token), p.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(X86TableSuite, TokenToX86Type,
+    testing::Values(
+        TokenToX86TypeParam("AL", TParaToken::ttReg8, "r8"),
+        TokenToX86TypeParam("AX", TParaToken::ttReg16, "r16"),
+        TokenToX86TypeParam("EAX", TParaToken::ttReg32, "r32"),
+        TokenToX86TypeParam("RAX", TParaToken::ttReg64, "r64"),
+        TokenToX86TypeParam("[AL]", TParaToken::ttMem8, "m8"),
+        TokenToX86TypeParam("[AX]", TParaToken::ttMem16, "m16"),
+        TokenToX86TypeParam("[EAX]", TParaToken::ttMem32, "m32"),
+        TokenToX86TypeParam("[RAX]", TParaToken::ttMem64, "m64"),
+        TokenToX86TypeParam("0x80", TParaToken::ttImm, "imm")
+    )
+);
+
+
 TEST_F(X86TableSuite, GetOutputSize)
 {
     auto iset = decode_json<InstructionSet>(std::string(X86_64_JSON));
@@ -66,4 +111,14 @@ TEST_F(X86TableSuite, GetOutputSize)
     EXPECT_EQ("x86-64", iset.instruction_set());
     EXPECT_EQ(1215, iset.instructions().size());
     EXPECT_EQ(1, iset.instructions().count("MOV"));
+
+
+    auto inst = iset.instructions().at("ADD");
+    auto size = inst.get_output_size(
+        {
+            TParaToken("[BX]", TParaToken::ttIdentifier, TParaToken::ttMem16),
+            TParaToken("AX", TParaToken::ttIdentifier, TParaToken::ttReg16)
+        }
+    );
+    EXPECT_EQ(3, size);
 }


### PR DESCRIPTION
ref #58

主にオペコードとオペランドを渡されたら必要な機械語のサイズを出力できるようにした

### 間接アドレス表現への対応

#### 簡単なテスト

```shell
$ echo "MOV AL,[SI]" | src/nask_parse --parse --scan ../test.img

[Abstract Syntax]
(Prog 
  [
    (MnemonicStmt [OpcodesMOV] [
      (MnemoArg [(ImmExp [(IdentFactor "AL")])]), 
      (MnemoArg [(IndirectAddrExp [(ImmExp [(IdentFactor "SI")])] )])
    ])
  ]
)

[Linearized Tree]
MOV AL, [SI]
```

まだ間接アドレス表現の`[ESP+4]`のような表記には対応できていない