### PR TITLE
opennaskの実装をbnfcの生成コードで置き換え(14)

### DIFF
--- a/parasol/samples/tutorial/yaciex/BitSet.cc
+++ b/parasol/samples/tutorial/yaciex/BitSet.cc
@@ -55,7 +55,7 @@ int TBitSetObject::DispatchMessage(const string& Message, vector<TParaValue*>& A
         ReturnValue = IsSet(ArgumentList);
     }
     else if (Message == "asInt") {
-        ReturnValue = AsInt(ArgumentList);
+        ReturnValue = AsUInt32(ArgumentList);
     }
     else if (Message == "asString") {
         ReturnValue = AsString(ArgumentList);
@@ -127,7 +127,7 @@ TParaValue TBitSetObject::IsSet(vector<TParaValue*>& ArgumentList) noexcept(fals
     return TParaValue(Result);
 }
 
-TParaValue TBitSetObject::AsInt(vector<TParaValue*>& ArgumentList) noexcept(false)
+TParaValue TBitSetObject::AsUInt32(vector<TParaValue*>& ArgumentList) noexcept(false)
 {
     return TParaValue(_Value);
 }

--- a/parasol/samples/tutorial/yaciex/BitSet.hh
+++ b/parasol/samples/tutorial/yaciex/BitSet.hh
@@ -26,7 +26,7 @@ class TBitSetObject: public TParaObjectPrototype {
     TParaValue Set(std::vector<TParaValue*>& ArgumentList) noexcept(false);
     TParaValue Unset(std::vector<TParaValue*>& ArgumentList) noexcept(false);
     TParaValue IsSet(std::vector<TParaValue*>& ArgumentList) noexcept(false);
-    TParaValue AsInt(std::vector<TParaValue*>& ArgumentList) noexcept(false);
+    TParaValue AsUInt32(std::vector<TParaValue*>& ArgumentList) noexcept(false);
     TParaValue AsString(std::vector<TParaValue*>& ArgumentList) noexcept(false);
   private:
     long _Value;

--- a/src/front_end.cc
+++ b/src/front_end.cc
@@ -838,25 +838,17 @@ void FrontEnd::processJMP(std::vector<TParaToken>& mnemonic_args) {
 
             // pass1のシンボルテーブルを使う
             int32_t jmp_offset = label_address - (dollar_position + binout_container.size());
-            log()->debug("[pass2] JMP label_adress: {}", label_address);
-            log()->debug("[pass2] JMP $: {}", dollar_position);
-            log()->debug("[pass2] JMP lc: {}", binout_container.size());
 
             match(jmp_offset)(
                 pattern | (std::numeric_limits<int8_t>::min() <= _ && _ <= std::numeric_limits<int8_t>::max()) = [&] {
-                    log()->debug("[pass2] JMP(b): {}", jmp_offset);
                     auto b = IntAsByte(jmp_offset - (1 + NASK_BYTE));
                     std::copy(b.begin(), b.end(), std::back_inserter(bytes));
                 },
                 pattern | (std::numeric_limits<int16_t>::min() <= _ && _ <= std::numeric_limits<int16_t>::max()) = [&] {
-                    // TODO: ここ本当はニアジャンプじゃないかな...
-                    log()->debug("[pass2] JMP(w): {}", jmp_offset);
                     auto b = IntAsWord(jmp_offset - (1 + NASK_WORD));
                     std::copy(b.begin(), b.end(), std::back_inserter(bytes));
                 },
                 pattern | (std::numeric_limits<int32_t>::min() <= _ && _ <= std::numeric_limits<int32_t>::max()) = [&] {
-                    // TODO: ここ本当はニアジャンプじゃないかな...
-                    log()->debug("[pass2] JMP(d): {}", jmp_offset);
                     auto b = LongAsDword(jmp_offset - (1 + NASK_DWORD));
                     std::copy(b.begin(), b.end(), std::back_inserter(bytes));
                 }

--- a/src/front_end.cc
+++ b/src/front_end.cc
@@ -9,6 +9,7 @@
 #include "parser.hh"
 #include "demangle.hpp"
 #include "mod_rm.hpp"
+#include "x86.hh"
 
 
 using namespace std::placeholders;
@@ -29,6 +30,9 @@ FrontEnd::FrontEnd(bool trace_scanning, bool trace_parsing) {
     // nask
     dollar_position = 0;
     equ_map = std::map<std::string, TParaToken>{};
+    iset = std::make_unique<x86_64::InstructionSet>(jsoncons::decode_json<x86_64::InstructionSet>(std::string(x86_64::X86_64_JSON)));
+
+    // TODO: 後ほど削除
     label_dst_list = LabelDstList{};
     label_src_list = LabelSrcList{};
 }
@@ -935,137 +939,27 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
 
     auto operands = std::make_tuple(
         mnemonic_args[0].AsAttr(),
+        mnemonic_args[0].AsString(),
         mnemonic_args[1].AsAttr(),
         mnemonic_args[1].AsString()
     );
 
+    auto inst = iset->instructions().at("MOV");
+    Id<std::string> dst;
+    Id<std::string> src;
+
     std::vector<uint8_t> machine_codes = match(operands)(
-        //         0x88 /r	MOV r/m8   , r8
-        // REX   + 0x88 /r	MOV r/m8   , r8
-        //
-        pattern | ds(or_(TParaToken::ttMem8, TParaToken::ttMem16) , TParaToken::ttReg8, _ != "AL") = [&] {
-            const std::string dst_mem = "[" + mnemonic_args[0].AsString() + "]";
-            const std::string src_reg = mnemonic_args[1].AsString();
+        // TODO: 全体的にオペコード, ModRMなどはx86テーブルから取得するようにする
 
-            const uint8_t base = 0x88;
-            const uint8_t modrm = ModRM::generate_modrm(base, ModRM::REG_REG, dst_mem, src_reg);
-            std::vector<uint8_t> b = {base, modrm};
-            auto imm = mnemonic_args[0].AsUInt16t(); // TODO: int16で返しているが実際は可変なのでちゃんと処理する
-            std::copy(imm.begin(), imm.end(), std::back_inserter(b));
-            return b;
-        },
-
-        //         0x89 /r	MOV r/m16  , r16
-        //         0x89 /r	MOV r/m32  , r32
-        // REX.W + 0x89 /r	MOV r/m64  , r64
-
-        //         0x8A /r	MOV r8     , r/m8
-        // REX   + 0x8A /r	MOV r8     , r/m8
-        //         0x8B /r	MOV r16    , r/m16
-        //         0x8B /r	MOV r32    , r/m32
-        // REX.W + 0x8B /r	MOV r64    , r/m64
-        pattern | ds(TParaToken::ttReg8 , or_(TParaToken::ttMem8, TParaToken::ttMem16), _) = [&] {
-            const std::string src_mem = "[" + mnemonic_args[1].AsString() + "]";
-            const std::string dst_reg = mnemonic_args[0].AsString();
-
-            const uint8_t base = 0x8a;
-            const uint8_t modrm = ModRM::generate_modrm(0x8e, ModRM::REG_REG, src_mem, dst_reg);
-            std::vector<uint8_t> b = {base, modrm};
-            return b;
-        },
-        pattern | ds(TParaToken::ttReg16, TParaToken::ttMem16, _) = [&] {
-            const std::string src_mem = "[" + mnemonic_args[1].AsString() + "]";
-            const std::string dst_reg = mnemonic_args[0].AsString();
-
-            const uint8_t base = 0x8b;
-            const uint8_t modrm = ModRM::generate_modrm(0x8e, ModRM::REG_REG, src_mem, dst_reg);
-            std::vector<uint8_t> b = {base, modrm};
-            return b;
-        },
-        pattern | ds(TParaToken::ttReg32, TParaToken::ttMem32, _) = [&] {
-            const std::string src_mem = "[" + mnemonic_args[1].AsString() + "]";
-            const std::string dst_reg = mnemonic_args[0].AsString();
-
-            const uint8_t base = 0x8b;
-            const uint8_t modrm = ModRM::generate_modrm(0x8e, ModRM::REG_REG, src_mem, dst_reg);
-            std::vector<uint8_t> b = {base, modrm};
-            return b;
-        },
-
-        //         0x8C /r	MOV r/m16  , Sreg
-        // REX.W + 0x8C /r	MOV r/m16  , Sreg
-        pattern | ds(TParaToken::ttReg16 , TParaToken::ttSreg, _) = [&] {
-            const std::string src = mnemonic_args[0].AsString();
-            const std::string dst = mnemonic_args[1].AsString();
-
-            const uint8_t base = 0x8c;
-            const uint8_t modrm = ModRM::generate_modrm(0x8c, ModRM::REG, dst, src);
-            std::vector<uint8_t> b = {base, modrm};
-            return b;
-        },
-
-        //         0x8E /r	MOV Sreg   , r/m16
-        // REX.W + 0x8E /r	MOV Sreg   , r/m64
-        pattern | ds(TParaToken::ttSreg , _, _) = [&] {
-            const std::string src = mnemonic_args[0].AsString();
-            const std::string dst = mnemonic_args[1].AsString();
-
-            const uint8_t base = 0x8e;
-            const uint8_t modrm = ModRM::generate_modrm(0x8e, ModRM::REG, dst, src);
-            std::vector<uint8_t> b = {base, modrm};
-            return b;
-        },
-
-        //         0xA0	    MOV AL     , moffs8
-        // REX.W + 0xA0	    MOV AL     , moffs8
-        //         0xA1	    MOV AX     , moffs16
-        //         0xA1	    MOV EAX    , moffs32
-        // REX.W + 0xA1	    MOV RAX    , moffs64
-
-        //         0xA2	    MOV moffs8 , AL
-        // REX.W + 0xA2	    MOV moffs8 , AL
-        //         0xA3	    MOV moffs16, AX
-        //		   0xA3		MOV moffs32, EAX
-        // REX.W + 0xA3		MOV moffs64, RAX
-        pattern | ds(TParaToken::ttMem16, TParaToken::ttReg8, "AL") = [&] {
-
-            const uint8_t base = 0xa2;
-            std::vector<uint8_t> b = {base};
-            auto addr = mnemonic_args[0].AsUInt16t();
-            std::copy(addr.begin(), addr.end(), std::back_inserter(b));
-            return b;
-        },
-        pattern | ds(TParaToken::ttMem16, TParaToken::ttReg16, "AX") = [&] {
-
-            const uint8_t base = 0xa3;
-            std::vector<uint8_t> b = {base};
-            auto addr = mnemonic_args[0].AsUInt16t();
-            std::copy(addr.begin(), addr.end(), std::back_inserter(b));
-            return b;
-        },
-        pattern | ds(TParaToken::ttMem32, TParaToken::ttReg32, "EAX") = [&] {
-
-            const uint8_t base = 0xa3;
-            std::vector<uint8_t> b = {base};
-            auto addr = mnemonic_args[0].AsUInt16t();
-            std::copy(addr.begin(), addr.end(), std::back_inserter(b));
-            return b;
-        },
-
-        //         0xB0+rb  MOV r8     , imm8
-        // REX   + 0xB0+rb  MOV r8     , imm8
-        //         0xB8+rw  MOV r16    , imm16
-        //         0xB8+rd  MOV r32    , imm32
-        pattern | ds(TParaToken::ttReg8 , TParaToken::ttImm, _) = [&] {
-            const std::string src = mnemonic_args[0].AsString();
-            const std::string dst = mnemonic_args[1].AsString();
-
+        // C6      r8      imm8 (TODO: こっちは実装していない)
+        // B0+rb   r8      imm8
+        pattern | ds(TParaToken::ttReg8, src, or_(TParaToken::ttImm, TParaToken::ttLabel), dst) = [&] {
             const uint8_t base = 0xb0;
-            const uint8_t opcode = ModRM::get_opecode_from_reg(base, src);
+            const uint8_t opcode = ModRM::get_opecode_from_reg(base, *src);
             std::vector<uint8_t> b = {opcode};
 
-            if (std::get<1>(operands) == TParaToken::ttLabel) {
-                std::string label = mnemonic_args[1].AsString();
+            if (std::get<2>(operands) == TParaToken::ttLabel) {
+                std::string label = *dst;
                 auto label_address = sym_table.at(label);
                 auto jmp_offset = label_address - dollar_position - binout_container.size();
 
@@ -1077,15 +971,37 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             }
             return b;
         },
-        pattern | ds(TParaToken::ttReg16, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            const std::string src = mnemonic_args[0].AsString();
-            const std::string dst = mnemonic_args[1].AsString();
+        //// 88      r8      r8
+        //pattern | ds(TParaToken::ttReg8, _, TParaToken::ttReg8, _) = [&] {
+        //},
+        // 8A      r8      m8
+        pattern | ds(TParaToken::ttReg8, dst, TParaToken::ttMem8, src) = [&] {
+            const std::string src_mem = "[" + *src + "]";
+            const std::string dst_reg = *dst;
+
+            const uint8_t base = 0x8a;
+            const uint8_t modrm = ModRM::generate_modrm(0x8e, ModRM::REG_REG, src_mem, dst_reg);
+            std::vector<uint8_t> b = {base, modrm};
+            return b;
+        },
+        pattern | ds(TParaToken::ttReg8, dst, TParaToken::ttMem16, src) = [&] {
+            const std::string src_mem = "[" + *src + "]";
+            const std::string dst_reg = *dst;
+
+            const uint8_t base = 0x8a;
+            const uint8_t modrm = ModRM::generate_modrm(0x8e, ModRM::REG_REG, src_mem, dst_reg);
+            std::vector<uint8_t> b = {base, modrm};
+            return b;
+        },
+        // C7      r16     imm16 (TODO: こっちは実装していない)
+        // B8+rw   r16     imm16
+        pattern | ds(TParaToken::ttReg16, src, or_(TParaToken::ttImm, TParaToken::ttLabel), dst) = [&] {
             const uint8_t base = 0xb8;
-            const uint8_t opcode = ModRM::get_opecode_from_reg(base, src);
+            const uint8_t opcode = ModRM::get_opecode_from_reg(base, *src);
             std::vector<uint8_t> b = {opcode};
 
-            if (std::get<1>(operands) == TParaToken::ttLabel) {
-                std::string label = mnemonic_args[1].AsString();
+            if (std::get<2>(operands) == TParaToken::ttLabel) {
+                std::string label = *dst;
                 auto label_address = sym_table.at(label);
                 auto offset = IntAsWord(label_address); // ここは絶対アドレスになるようだ
                 std::copy(offset.begin(), offset.end(), std::back_inserter(b));
@@ -1096,16 +1012,31 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
 
             return b;
         },
-        pattern | ds(TParaToken::ttReg32, TParaToken::ttImm, _) = [&] {
-            const std::string src = mnemonic_args[0].AsString();
-            const std::string dst = mnemonic_args[1].AsString();
+        //// 89      r16     r16
+        //pattern | ds(TParaToken::ttReg16, _, TParaToken::ttReg16, _) = [&] {
+        //},
+        // 8B      r16     m16
+        pattern | ds(TParaToken::ttReg16, dst, TParaToken::ttMem16, src) = [&] {
+            const std::string src_mem = "[" + *src + "]";
+            const std::string dst_reg = *dst;
 
+            const uint8_t base = 0x8b;
+            const uint8_t modrm = ModRM::generate_modrm(0x8e, ModRM::REG_REG, src_mem, dst_reg);
+            std::vector<uint8_t> b = {base, modrm};
+            return b;
+        },
+        //// A1      eax     moffs32
+        //pattern | ds(TParaToken::ttReg32, "EAX", _, _) = [&] {
+        //},
+        // C7      r32     imm32 (TODO: こっちは実装していない)
+        // 0xB8+rd r32     imm32
+        pattern | ds(TParaToken::ttReg32, src, or_(TParaToken::ttImm, TParaToken::ttLabel), dst) = [&] {
             const uint8_t base = 0xb8;
-            const uint8_t opcode = ModRM::get_opecode_from_reg(base, src);
+            const uint8_t opcode = ModRM::get_opecode_from_reg(base, *src);
             std::vector<uint8_t> b = {opcode};
 
-            if (std::get<1>(operands) == TParaToken::ttLabel) {
-                std::string label = mnemonic_args[1].AsString();
+            if (std::get<2>(operands) == TParaToken::ttLabel) {
+                std::string label = *dst;
                 auto label_address = sym_table.at(label);
                 auto offset = LongAsDword(label_address); // ここは絶対アドレスになるようだ
                 std::copy(offset.begin(), offset.end(), std::back_inserter(b));
@@ -1115,16 +1046,36 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             }
             return b;
         },
+        //// 89      r32     r32
+        //pattern | ds(TParaToken::ttReg32, _, TParaToken::ttReg32, _) = [&] {
+        //},
+        // 8B      r32     m32
+        pattern | ds(TParaToken::ttReg32, dst, TParaToken::ttMem32, src) = [&] {
+            const std::string src_mem = "[" + *src + "]";
+            const std::string dst_reg = *dst;
 
-        // REX.W + 0xB8+rd	MOV r64    , imm64
-        //         0xC6 /0	MOV r/m8   , imm8
-        // REX.W + 0xC6 /0	MOV r/m8   , imm8
-        //         0xC7 /0	MOV r/m16  , imm16
-        //         0xC7 /0	MOV r/m32  , imm32
-        // REX.W + 0xC7 /0	MOV r/m64  , imm64
-        pattern | ds(TParaToken::ttMem8, TParaToken::ttImm, _) = [&] {
-            std::string dst = "[" + mnemonic_args[0].AsString() + "]";
-            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG_REG, dst, ModRM::SLASH_0);
+            const uint8_t base = 0x8b;
+            const uint8_t modrm = ModRM::generate_modrm(0x8e, ModRM::REG_REG, src_mem, dst_reg);
+            std::vector<uint8_t> b = {base, modrm};
+            return b;
+        },
+        //// A1      rax     moffs64
+        //pattern | ds(TParaToken::ttReg64, "RAX", _, _) = [&] {
+        //},
+        //// C7      r64     imm32
+        //// B8      r64     imm64
+        //pattern | ds(TParaToken::ttReg64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
+        //},
+        //// 89      r64     r64
+        //pattern | ds(TParaToken::ttReg64, _, TParaToken::ttReg64, _) = [&] {
+        //},
+        //// 8B      r64     m64
+        //pattern | ds(TParaToken::ttReg64, _, TParaToken::ttMem64, _) = [&] {
+        //},
+        // C6      m8      imm8
+        pattern | ds(TParaToken::ttMem8, dst, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
+            std::string dst_mem = "[" + *dst + "]";
+            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG_REG, dst_mem, ModRM::SLASH_0);
 
             std::vector<uint8_t> b = {0xc6, modrm};
             auto addr = mnemonic_args[0].AsUInt16t();
@@ -1133,9 +1084,26 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             std::copy(imm.begin(), imm.end(), std::back_inserter(b));
             return b;
         },
-        pattern | ds(TParaToken::ttMem16, TParaToken::ttImm, _) = [&] {
-            std::string dst = "[" + mnemonic_args[0].AsString() + "]";
-            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG_REG, dst, ModRM::SLASH_0);
+        // 88      m8      r8
+        // 88      m16     r8 (m16の場合下位8ビットが使われる)
+        pattern | ds(or_(TParaToken::ttMem8, TParaToken::ttMem16), dst, TParaToken::ttReg8, src) = [&] {
+            auto token = TParaToken(mnemonic_args[0]);
+            token.SetAttribute(TParaToken::ttMem8);
+            // `MOV [0x0ff0],CH` だと0x0ff0部分を機械語に足す
+            const std::string dst_mem = "[" + *dst + "]";
+            const std::string src_reg = *src;
+
+            const uint8_t base = 0x88;
+            const uint8_t modrm = ModRM::generate_modrm(base, ModRM::REG_REG, dst_mem, src_reg);
+            std::vector<uint8_t> b = {base, modrm};
+            auto imm = mnemonic_args[0].AsUInt16t(); // TODO: int16で返しているが実際は可変なのでちゃんと処理する
+            std::copy(imm.begin(), imm.end(), std::back_inserter(b));
+            return b;
+        },
+        // C7      m16     imm16
+        pattern | ds(TParaToken::ttMem16, dst, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
+            std::string dst_mem = "[" + *dst + "]";
+            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG_REG, dst_mem, ModRM::SLASH_0);
 
             std::vector<uint8_t> b = {0xc7, modrm};
             auto addr = mnemonic_args[0].AsUInt16t();
@@ -1144,9 +1112,13 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             std::copy(imm.begin(), imm.end(), std::back_inserter(b));
             return b;
         },
-        pattern | ds(TParaToken::ttMem32, TParaToken::ttImm, _) = [&] {
-            std::string dst = "[" + mnemonic_args[0].AsString() + "]";
-            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG_REG, dst, ModRM::SLASH_0);
+        //// 89      m16     r16
+        //pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
+        //},
+        // C7      m32     imm32
+        pattern | ds(TParaToken::ttMem32, dst, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
+            std::string dst_mem = "[" + *dst + "]";
+            const uint8_t modrm = ModRM::generate_modrm(ModRM::REG_REG, dst_mem, ModRM::SLASH_0);
 
             // Override prefixes(0x66)
             // TODO: 16bit命令モードで動作中のみ0x66を付与するようにする
@@ -1155,6 +1127,55 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             std::copy(addr.begin(), addr.end(), std::back_inserter(b));
             auto imm = mnemonic_args[1].AsUInt32t();
             std::copy(imm.begin(), imm.end(), std::back_inserter(b));
+            return b;
+        },
+        //// 89      m32     r32
+        //pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {
+        //},
+        //// C7      m64     imm32
+        //pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
+        //},
+        //// 89      m64     r64
+        //pattern | ds(TParaToken::ttMem64, _, TParaToken::ttReg64, _) = [&] {
+        //},
+        // A2      moffs8  al
+        pattern | ds(or_(TParaToken::ttMem8, TParaToken::ttMem16), _, TParaToken::ttReg8, "AL") = [&] {
+            const uint8_t base = 0xa2;
+            std::vector<uint8_t> b = {base};
+            auto addr = mnemonic_args[0].AsUInt16t();
+            std::copy(addr.begin(), addr.end(), std::back_inserter(b));
+            return b;
+        },
+        // A3      moffs16 ax
+        pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, "AX") = [&] {
+            const uint8_t base = 0xa3;
+            std::vector<uint8_t> b = {base};
+            auto addr = mnemonic_args[0].AsUInt16t();
+            std::copy(addr.begin(), addr.end(), std::back_inserter(b));
+            return b;
+        },
+        // A3      moffs32 eax
+        pattern | ds(_, _, TParaToken::ttReg32, "EAX") = [&] {
+            const uint8_t base = 0xa3;
+            std::vector<uint8_t> b = {base};
+            auto addr = mnemonic_args[0].AsUInt32t();
+            std::copy(addr.begin(), addr.end(), std::back_inserter(b));
+            return b;
+        },
+        //// A3      moffs64 rax
+        //pattern | ds(_, _, TParaToken::ttReg64, "RAX") = [&] {
+        //},
+        // 以下、セグメントレジスタはx86-jsonに記載なし
+        pattern | ds(TParaToken::ttSreg, src, _, dst) = [&] {
+            const uint8_t base = 0x8e;
+            const uint8_t modrm = ModRM::generate_modrm(0x8e, ModRM::REG, *dst, *src);
+            std::vector<uint8_t> b = {base, modrm};
+            return b;
+        },
+        pattern | ds(TParaToken::ttReg16, dst, TParaToken::ttSreg, src) = [&] {
+            const uint8_t base = 0x8c;
+            const uint8_t modrm = ModRM::generate_modrm(0x8c, ModRM::REG, *dst, *src);
+            std::vector<uint8_t> b = {base, modrm};
             return b;
         },
         pattern | _ = [&] {
@@ -1489,7 +1510,6 @@ void FrontEnd::visitString(String x) {
 }
 
 void FrontEnd::visitIdent(Ident x) {
-    // TODO: ラベルの変数定義を先に作っておく必要がありそう
     if (equ_map.count(x) > 0) {
         // 変数定義があれば展開する
         log()->debug("[pass2] EQU {} = {}", x, equ_map[x].AsString());

--- a/src/front_end.hh
+++ b/src/front_end.hh
@@ -39,10 +39,13 @@ public:
     // Pass1のシンボルテーブル, リテラルテーブル
     std::map<std::string, TParaToken> equ_map;
     std::map<std::string, uint32_t> sym_table;
+    // x86命令セット
+    std::unique_ptr<x86_64::InstructionSet> iset;
 
     // 出力するバイナリ情報
     std::vector<uint8_t> binout_container;
     // ラベルによるオフセットの計算をする
+    // TODO: 後ほど削除する
     LabelDstList label_dst_list;
     LabelSrcList label_src_list;
 

--- a/src/para_token.cc
+++ b/src/para_token.cc
@@ -256,6 +256,10 @@ std::array<uint8_t, 4> TParaToken::AsUInt32t() const {
 }
 
 size_t TParaToken::GetImmSize() const {
+    if (!IsHex()) {
+        return 0;
+    }
+
     const std::string supplied_hex = (_token_string.substr(2).size() % 2 == 0) ?
         _token_string.substr(2) : "0" + _token_string.substr(2);
     const size_t s = supplied_hex.size() / 2;

--- a/src/para_token.cc
+++ b/src/para_token.cc
@@ -153,18 +153,15 @@ string TParaToken::AsString(void) const {
     return _token_string;
 }
 
-int TParaToken::AsInt(void) const noexcept(false) {
+uint32_t TParaToken::AsUInt32(void) const noexcept(false) {
     if (! IsInteger() && ! IsHex() ) {
         ThrowUnexpected("integer");
     }
 
-    int int_value;
+    uint32_t int_value;
     if ((_token_string.size() > 2) && (tolower(_token_string[1]) == 'x')) {
         // Hex Number
-        istringstream value_stream(_token_string.substr(2, string::npos));
-        if (! (value_stream >> hex >> int_value)) {
-            ThrowUnexpected("integer");
-        }
+        return static_cast<uint32_t>(std::stoul(_token_string, nullptr, 16));
     } else {
         // Dec Number
         istringstream value_stream(_token_string);
@@ -236,12 +233,12 @@ double TParaToken::AsDouble(void) const noexcept(false) {
 }
 
 std::array<uint8_t, 1> TParaToken::AsUInt8t() const {
-    const int v = AsInt();
+    const int v = AsUInt32();
     return std::array<uint8_t, 1>{static_cast<uint8_t>(v)};
 }
 
 std::array<uint8_t, 2> TParaToken::AsUInt16t() const {
-    const int word = AsInt();
+    const int word = AsUInt32();
     return std::array<uint8_t, 2>{
         static_cast<uint8_t>( word & 0xff ),
         static_cast<uint8_t>( (word >> 8) & 0xff ),

--- a/src/para_token.hh
+++ b/src/para_token.hh
@@ -118,7 +118,7 @@ public:
     bool Is(const std::string& string) const;
     bool IsNot(const std::string& string) const;
     std::string AsString(void) const;
-    int AsInt(void) const noexcept(false);
+    uint32_t AsUInt32(void) const noexcept(false);
     int32_t AsInt32(void) const noexcept(false);
     double AsDouble(void) const noexcept(false);
     std::array<uint8_t, 1> AsUInt8t(void) const noexcept(false);

--- a/src/pass1_strategy.cc
+++ b/src/pass1_strategy.cc
@@ -876,6 +876,9 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
     // cat json-x86-64/x86_64.json | \
     // jq -r '.instructions["MOV"].forms[] | [.encodings[0].opcode.byte, .operands[0].type, .operands[1].type ] | @tsv'
     // -- パターンは25個ある
+    // TODO: x86 tableに下記1行の記載なし
+    // B0+rb   r8      imm8
+    //
     // C6      r8      imm8
     // 88      r8      r8
     // 8A      r8      m8
@@ -899,6 +902,10 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
     // 89      m32     r32
     // C7      m64     imm32
     // 89      m64     r64
+    // TODO: x86 tableに下記2行の記載なし
+    // A2      moffs8  al
+    // A3      moffs16 ax
+    //
     // A3      moffs32 eax
     // A3      moffs64 rax
     auto inst = iset->instructions().at("MOV");

--- a/src/pass1_strategy.cc
+++ b/src/pass1_strategy.cc
@@ -976,7 +976,10 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
         },
         // C6      m8      imm8
         pattern | ds(TParaToken::ttMem8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            // `MOV BYTE [addr_size], X`
+            auto addr_size = mnemonic_args[0].GetImmSize();
+            auto size = addr_size + inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return size;
         },
         // 88      m8      r8
         // 88      m16     r8 (m16の場合下位8ビットが使われる)
@@ -989,7 +992,10 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
         },
         // C7      m16     imm16
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            // `MOV WORD [addr_size], X`
+            auto addr_size = mnemonic_args[0].GetImmSize();
+            auto size = addr_size + inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return size;
         },
         // 89      m16     r16
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
@@ -997,7 +1003,12 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
         },
         // C7      m32     imm32
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            // `MOV DWORD [addr_size], X`
+            // TODO: x86 tableの定義に`prefix`の定義がない
+            auto override_prefix_size = (bit_mode != ID_32BIT_MODE) ? 1 : 0;
+            auto addr_size = mnemonic_args[0].GetImmSize();
+            auto size = override_prefix_size + addr_size + inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return size;
         },
         // 89      m32     r32
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {

--- a/src/pass1_strategy.cc
+++ b/src/pass1_strategy.cc
@@ -1056,7 +1056,7 @@ void Pass1Strategy::processNOP() {
 void Pass1Strategy::processORG(std::vector<TParaToken>& mnemonic_args) {
     auto arg = mnemonic_args[0];
     arg.MustBe(TParaToken::ttHex);
-    loc = arg.AsInt32();
+    loc = arg.AsUInt32();
     log()->debug("[pass1] LOC = {}({:x})", std::to_string(loc), loc);
 }
 

--- a/src/x86.cc
+++ b/src/x86.cc
@@ -69,7 +69,6 @@ namespace x86_64 {
         if (code_offset_) {
             output_size += code_offset_->size();
         }
-;
         return output_size;
     }
 

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -1011,8 +1011,6 @@ fin:
     d->Eval<Program>(pt.get(), "test.img");
 
     std::vector<uint8_t> expected = {};
-    std::vector<uint8_t> resb18(18, 0);
-    //std::vector<uint8_t> padding(297, 0);
 
     // haribote.nas
     expected.insert(expected.end(), {0xb0, 0x13});
@@ -1026,7 +1024,6 @@ fin:
     expected.insert(expected.end(), {0xb4, 0x02});
     expected.insert(expected.end(), {0xcd, 0x16});
 
-    GTEST_SKIP(); // TODO: 以降まだ機能しない
     expected.insert(expected.end(), {0x88, 0x06});
     expected.insert(expected.end(), {0xf1, 0x0f});
     expected.insert(expected.end(), {0xf4});

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -10,7 +10,7 @@ class Day03Suite : public ::testing::Test {
 protected:
     // 試験開始時に一回だけ実行
     Day03Suite() {
-        //spdlog::set_level(spdlog::level::debug);
+        spdlog::set_level(spdlog::level::debug);
     }
 
     // 試験終了時に一回だけ実行
@@ -1025,13 +1025,14 @@ fin:
 
     expected.insert(expected.end(), {0xb4, 0x02});
     expected.insert(expected.end(), {0xcd, 0x16});
+
+    GTEST_SKIP(); // TODO: 以降まだ機能しない
     expected.insert(expected.end(), {0x88, 0x06});
     expected.insert(expected.end(), {0xf1, 0x0f});
     expected.insert(expected.end(), {0xf4});
     expected.insert(expected.end(), {0xeb, 0xfd});
 
     // 作成したバイナリの差分assert & diff表示
-    GTEST_SKIP(); // TODO: まだ機能しない
     ASSERT_PRED_FORMAT2(checkTextF,expected,d->binout_container);
 }
 

--- a/test/diff.hh
+++ b/test/diff.hh
@@ -116,8 +116,13 @@ std::vector<T> slice(std::vector<T> const &v, int m, int n) {
         return ::testing::AssertionSuccess();
 
     // 差分が有る場合でも最初の300byteまでしか出さない
-    auto expected_slice = slice(expected, 0, 300);
-    auto actual_slice = slice(actual, 0, 300);
+    size_t slice_size = 300;
+    if (expected.size() <= 300 && actual.size() <= 300) {
+        // 出力が300byte以下だった場合は想定値とテスト結果のうち大きい方のサイズで差分を出す
+        slice_size = std::max(expected.size(), actual.size());
+    }
+    auto expected_slice = slice(expected, 0, slice_size);
+    auto actual_slice = slice(actual, 0, slice_size);
 
     const std::string msg = "[diff]\n" + diff(expected_slice, actual_slice);
     return ::testing::AssertionFailure(::testing::Message(msg.c_str()));

--- a/test/exp_suite.cpp
+++ b/test/exp_suite.cpp
@@ -33,7 +33,7 @@ TEST_F(ExpSuite, ParaToken)
     std::unique_ptr<FrontEnd> d(new FrontEnd(false, false));
 
     d->visitInteger(30);
-    EXPECT_EQ(30, d->ctx.top().AsInt());
+    EXPECT_EQ(30, d->ctx.top().AsUInt32());
     d->ctx.pop();
 
     d->visitChar('H');
@@ -63,7 +63,7 @@ TEST_F(ExpSuite, Factor)
     std::unique_ptr<FrontEnd> d(new FrontEnd(false, false));
     auto numberFactor = NumberFactor(30);
     d->visitNumberFactor(&numberFactor);
-    EXPECT_EQ(30, d->ctx.top().AsInt());
+    EXPECT_EQ(30, d->ctx.top().AsUInt32());
     d->ctx.pop();
 
     auto hexFactor = HexFactor("hello1");
@@ -94,7 +94,7 @@ TEST_F(ExpSuite, ImmExp)
     {
         auto immExp = ImmExp(numberFactor.clone());
         d->visitImmExp(&immExp);
-        EXPECT_EQ(30, d->ctx.top().AsInt());
+        EXPECT_EQ(30, d->ctx.top().AsUInt32());
         d->ctx.pop();
     }
     {
@@ -172,31 +172,31 @@ TEST_F(ExpSuite, ArithmeticOperations)
     {
         auto plusExp = PlusExp(immExp1.clone(), immExp2.clone());
         d->visitPlusExp(&plusExp);
-        EXPECT_EQ(10, d->ctx.top().AsInt());
+        EXPECT_EQ(10, d->ctx.top().AsUInt32());
         d->ctx.pop();
     }
     {
         auto minusExp = MinusExp(immExp1.clone(), immExp2.clone());
         d->visitMinusExp(&minusExp);
-        EXPECT_EQ(4, d->ctx.top().AsInt());
+        EXPECT_EQ(4, d->ctx.top().AsUInt32());
         d->ctx.pop();
     }
     {
         auto mulExp = MulExp(immExp1.clone(), immExp2.clone());
         d->visitMulExp(&mulExp);
-        EXPECT_EQ(21, d->ctx.top().AsInt());
+        EXPECT_EQ(21, d->ctx.top().AsUInt32());
         d->ctx.pop();
     }
     {
         auto divExp = DivExp(immExp1.clone(), immExp2.clone());
         d->visitDivExp(&divExp);
-        EXPECT_EQ(2, d->ctx.top().AsInt());
+        EXPECT_EQ(2, d->ctx.top().AsUInt32());
         d->ctx.pop();
     }
     {
         auto modExp = ModExp(immExp1.clone(), immExp2.clone());
         d->visitModExp(&modExp);
-        EXPECT_EQ(1, d->ctx.top().AsInt());
+        EXPECT_EQ(1, d->ctx.top().AsUInt32());
         d->ctx.pop();
     }
 }
@@ -210,7 +210,7 @@ TEST_F(ExpSuite, MnemoArgs)
         auto mnemoArg = MnemoArg(immExp.clone());
 
         d->visitMnemoArg(&mnemoArg);
-        EXPECT_EQ(12, d->ctx.top().AsInt());
+        EXPECT_EQ(12, d->ctx.top().AsUInt32());
         d->ctx.pop();
     }
     {
@@ -224,9 +224,9 @@ TEST_F(ExpSuite, MnemoArgs)
         d->visitListMnemonicArgs(&mnemoArgs);
         EXPECT_EQ(2, d->ctx.size());
 
-        EXPECT_EQ(13, d->ctx.top().AsInt());
+        EXPECT_EQ(13, d->ctx.top().AsUInt32());
         d->ctx.pop();
-        EXPECT_EQ(12, d->ctx.top().AsInt());
+        EXPECT_EQ(12, d->ctx.top().AsUInt32());
         d->ctx.pop();
     }
 }
@@ -275,11 +275,11 @@ TEST_F(ExpSuite, DeclareStmt)
         auto declareStmt = DeclareStmt("CYLS", immExp.clone());
 
         d->visitDeclareStmt(&declareStmt);
-        EXPECT_EQ(10, d->equ_map["CYLS"].AsInt());
+        EXPECT_EQ(10, d->equ_map["CYLS"].AsUInt32());
 
         d->visitIdent("CYLS");
         EXPECT_EQ("10", d->ctx.top().AsString());
-        EXPECT_EQ(10, d->ctx.top().AsInt());
+        EXPECT_EQ(10, d->ctx.top().AsUInt32());
         d->ctx.pop();
     }
 }


### PR DESCRIPTION
ref #32 

## 対応内容
- ３日目のテスト追加(harib00h)
  - [３日目のアセンブラをダンプ（後編）](https://github.com/HobbyOSs/opennask/wiki/%EF%BC%93%E6%97%A5%E7%9B%AE%E3%81%AE%E3%82%A2%E3%82%BB%E3%83%B3%E3%83%96%E3%83%A9%E3%82%92%E3%83%80%E3%83%B3%E3%83%97%EF%BC%88%E5%BE%8C%E7%B7%A8%EF%BC%89)

- 次はharib00i