### PR TITLE
JMP系命令のオフセット不整合を修正

### DIFF
--- a/src/front_end/front_inst.cc
+++ b/src/front_end/front_inst.cc
@@ -361,15 +361,8 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             // 88      m8      r8
             pattern | ds(TParaToken::ttMem8, _, TParaToken::ttReg8, _) = [&] {
                 // TODO: test & メモリーアドレッシング
-                // TODO: 実装がとても雑
-                // TODO: test & メモリーアドレッシング
-                // TODO: 実装がとても雑
-                if (src.IsAsmJitGpbLo()) {
-                    a.mov(x86::byte_ptr(dst.AsInt32()), src.AsAsmJitGpbLo() );
-                } else if (src.IsAsmJitGpbHi()) {
-                    a.mov(x86::byte_ptr(dst.AsInt32()), src.AsAsmJitGpbHi() );
-                } else {
-                    // TODO: かなり間に合わせな実装、できればasmtkなどを使ってカスタマイズしたい
+                if (dst.IsImmediate()) {
+                    // asmjitでMOV [offset],Reg の場合独自実装が必要
                     // asmjit使用時にメモリーアドレッシング時にオフセットのみのMOVは機械語が想定と違う
                     a.db(0x88);
                     a.db(ModRM::generate_modrm(0x88,
@@ -377,18 +370,20 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
                                                std::string("[" + dst.AsString() + "]"),
                                                std::string(src.AsString())));
                     a.dw(dst.AsInt32());
+                    return;
+                }
+
+                if (src.IsAsmJitGpbLo()) {
+                    a.mov(x86::byte_ptr(dst.AsInt32()), src.AsAsmJitGpbLo() );
+                } else if (src.IsAsmJitGpbHi()) {
+                    a.mov(x86::byte_ptr(dst.AsInt32()), src.AsAsmJitGpbHi() );
                 }
             },
             // 88      m16     r8 (m16の場合下位8ビットが使われる)
             pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg8, _) = [&] {
                 // TODO: test & メモリーアドレッシング
-                // TODO: 実装がとても雑
-                if (src.IsAsmJitGpbLo()) {
-                    a.mov(x86::byte_ptr(dst.AsInt32()), src.AsAsmJitGpbLo() );
-                } else if (src.IsAsmJitGpbHi()) {
-                    a.mov(x86::byte_ptr(dst.AsInt32()), src.AsAsmJitGpbHi() );
-                } else {
-                    // TODO: かなり間に合わせな実装、できればasmtkなどを使ってカスタマイズしたい
+                if (dst.IsImmediate()) {
+                    // asmjitでMOV [offset],Reg の場合独自実装が必要
                     // asmjit使用時にメモリーアドレッシング時にオフセットのみのMOVは機械語が想定と違う
                     a.db(0x88);
                     a.db(ModRM::generate_modrm(0x88,
@@ -396,6 +391,14 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
                                                std::string("[" + dst.AsString() + "]"),
                                                std::string(src.AsString())));
                     a.dw(dst.AsInt32());
+                    return;
+                }
+
+                // TODO: 実装がとても雑
+                if (src.IsAsmJitGpbLo()) {
+                    a.mov(x86::byte_ptr(dst.AsInt32()), src.AsAsmJitGpbLo() );
+                } else if (src.IsAsmJitGpbHi()) {
+                    a.mov(x86::byte_ptr(dst.AsInt32()), src.AsAsmJitGpbHi() );
                 }
             },
             // C7      m16     imm16

--- a/src/front_end/front_inst_jmp.cc
+++ b/src/front_end/front_inst_jmp.cc
@@ -260,19 +260,19 @@ void FrontEnd::processJMP(std::vector<TParaToken>& mnemonic_args) {
         pattern | ds(TParaToken::ttImm, 1) = [&] {
             with_asmjit([&](asmjit::x86::Assembler& a, PrefixInfo& pp) {
                 a.db(0xeb);
-                a.db(arg.AsInt32() - dollar_position - binout_container.size() + 1);
+                a.db(arg.AsInt32() - dollar_position - code_.codeSize() + 2);
             });
         },
         pattern | ds(TParaToken::ttImm, 2) = [&] {
             with_asmjit([&](asmjit::x86::Assembler& a, PrefixInfo& pp) {
                 a.db(0xe9);
-                a.dw(arg.AsInt32() - dollar_position - binout_container.size() + 1);
+                a.dw(arg.AsInt32() - dollar_position - code_.codeSize() + 2);
             });
         },
         pattern | ds(TParaToken::ttImm, 4) = [&] {
             with_asmjit([&](asmjit::x86::Assembler& a, PrefixInfo& pp) {
                 a.db(0xe9);
-                a.dd(arg.AsInt32() - dollar_position - binout_container.size() + 1);
+                a.dd(arg.AsInt32() - dollar_position - code_.codeSize() + 2);
             });
         },
         // ラベル処理

--- a/src/front_end/front_inst_jmp.cc
+++ b/src/front_end/front_inst_jmp.cc
@@ -254,17 +254,25 @@ void FrontEnd::processJMP(std::vector<TParaToken>& mnemonic_args) {
     auto arg = mnemonic_args[0];
 
     match(operands)(
-        // 即値処理
+        // asmjitでのJMP即値処理はうまい方法がないので下記のように実装しておく
+        // そもそも即値へのジャンプというのが一般的ではないのかもしれない
+        // MEMO: https://stackoverflow.com/a/63500826/2565527
         pattern | ds(TParaToken::ttImm, 1) = [&] {
             with_asmjit([&](asmjit::x86::Assembler& a, PrefixInfo& pp) {
-                const auto imm = (arg.AsInt32() - dollar_position - binout_container.size()) + 1;
-                a.short_().jmp(imm);
+                a.db(0xeb);
+                a.db(arg.AsInt32() - dollar_position - binout_container.size() + 1);
             });
         },
-        pattern | ds(TParaToken::ttImm, or_(2, 4)) = [&] {
+        pattern | ds(TParaToken::ttImm, 2) = [&] {
             with_asmjit([&](asmjit::x86::Assembler& a, PrefixInfo& pp) {
-                const auto imm = (arg.AsInt32() - dollar_position - binout_container.size()) + 1;
-                a.long_().jmp(imm);
+                a.db(0xe9);
+                a.dw(arg.AsInt32() - dollar_position - binout_container.size() + 1);
+            });
+        },
+        pattern | ds(TParaToken::ttImm, 4) = [&] {
+            with_asmjit([&](asmjit::x86::Assembler& a, PrefixInfo& pp) {
+                a.db(0xe9);
+                a.dd(arg.AsInt32() - dollar_position - binout_container.size() + 1);
             });
         },
         // ラベル処理

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -963,7 +963,7 @@ msg:
     expected.insert(expected.end(), std::begin(padding), std::end(padding));
     expected.insert(expected.end(), {0x55, 0xaa});
 
-    GTEST_SKIP(); // TODO: まだ機能しない
+    //GTEST_SKIP(); // TODO: まだ機能しない
     // 作成したバイナリの差分assert & diff表示
     ASSERT_PRED_FORMAT2(checkTextF,expected,d->binout_container);
 }
@@ -1030,7 +1030,6 @@ fin:
     expected.insert(expected.end(), {0xf4});
     expected.insert(expected.end(), {0xeb, 0xfd});
 
-    GTEST_SKIP(); // TODO: まだ機能しない
     // 作成したバイナリの差分assert & diff表示
     ASSERT_PRED_FORMAT2(checkTextF,expected,d->binout_container);
 }

--- a/test/inst_suite.cpp
+++ b/test/inst_suite.cpp
@@ -126,9 +126,9 @@ INSTANTIATE_TEST_SUITE_P(InstSuite, StatementToMachineCode,
         StatementToMachineCodeParam(ID_32BIT_MODE, "MOV ESI,0x7c00", std::vector<uint8_t>{0xbe, 0x00, 0x7c, 0x00, 0x00}),
         StatementToMachineCodeParam(ID_16BIT_MODE, "MOV SP,0x7c00", std::vector<uint8_t>{0xbc, 0x00, 0x7c}),
         StatementToMachineCodeParam(ID_16BIT_MODE, "MOV BX,SP", std::vector<uint8_t>{0x89, 0xe3}),
-        StatementToMachineCodeParam(ID_16BIT_MODE, "MOV SP,BX", std::vector<uint8_t>{0x89, 0xdc})
-        // TODO: まだ機能しない
-        //StatementToMachineCodeParam(ID_16BIT_MODE, "MOV [0x0ff0],CH", std::vector<uint8_t>{0x88, 0x2e, 0xf0, 0x0f})*/
+        StatementToMachineCodeParam(ID_16BIT_MODE, "MOV SP,BX", std::vector<uint8_t>{0x89, 0xdc}),
+        StatementToMachineCodeParam(ID_16BIT_MODE, "JMP 0xc200", std::vector<uint8_t>{0xe9, 0x01, 0xc2}),
+        StatementToMachineCodeParam(ID_16BIT_MODE, "MOV [0x0ff0],CH", std::vector<uint8_t>{0x88, 0x2e, 0xf0, 0x0f})
     )
 );
 


### PR DESCRIPTION
ref #73

#73 の修正前の微修正
このあとようやくメモリーアドレッシング表現をBNFに入れて、それをasmjitのメモリー表現で使う

下記commitを取り込む
- 8b385c71f7d2fbebf04985e06452d5401dfef90f
- 58d37210314ae4aeb86b933d395459e4b11f9bef

どうもasmjitは 
- `MOV [offset],Reg` 
- `JMP offset`

の場合独自実装が必要そう。まあ仕方ない。