### PR TITLE
EBNF版のnask_parseで実装を置き換え(2)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Configure CMake
       run: |
         cmake -B ${{github.workspace}}/build -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release              \
               -DCMAKE_C_COMPILER=clang                \
               -DCMAKE_CXX_COMPILER=clang++            \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache      \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,14 @@ project(root CXX)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 project(root)
 
+#-----------------------------------------------------------------------
+# Dev macro
+#
+
+#set(CMAKE_BUILD_TYPE "Debug" CACHE INTERNAL "cmake build type")
 #set(CMAKE_C_COMPILER "/usr/bin/clang" CACHE INTERNAL "clang compiler")
 #set(CMAKE_CXX_COMPILER "/usr/bin/clang++" CACHE INTERNAL "clang++ compiler")
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
 
 set(WINE "/usr/bin/wine" CACHE INTERNAL "")

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ $ ninja
 $ CMAKE_OPT="-DWITH_BACKWARDS_CPP=ON" ./ninja_build.sh
 
 # clang is faster than gcc
-$ CMAKE_OPT="CMAKE_C_COMPILER=clang CMAKE_CXX_COMPILER=clang++" ./ninja_build.sh
-```
+$ CMAKE_OPT="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++" ./ninja_build.sh
+  ```
 
 # Build osask project files (debian)
 

--- a/src/para_token.cc
+++ b/src/para_token.cc
@@ -78,6 +78,10 @@ x86::Mem& TParaToken::AsMem() const {
     return *_mem.get();
 }
 
+bool TParaToken::IsMem() const {
+    return _mem != nullptr;
+}
+
 int16_t TParaToken::AsSegment() const {
     return _segment;
 }

--- a/src/para_token.hh
+++ b/src/para_token.hh
@@ -132,6 +132,7 @@ public:
     bool IsNot(const std::string& string) const;
     std::string AsString(void) const;
     asmjit::x86::Mem& AsMem(void) const;
+    bool IsMem(void) const;
     int16_t AsSegment(void) const;
 
     // asmjit provides following datatype

--- a/src/pass1_strategy.cc
+++ b/src/pass1_strategy.cc
@@ -889,7 +889,9 @@ void Pass1Strategy::processIMUL(std::vector<TParaToken>& mnemonic_args) {
                          TParaToken::ttMem16,
                          TParaToken::ttMem32,
                          TParaToken::ttMem64), std::nullopt, std::nullopt) = [&] {
-                             return inst.get_output_size(bit_mode, mnemonic_args);
+                             // 1個だけ渡す
+                             std::vector<TParaToken> slice(mnemonic_args.begin(), mnemonic_args.begin() + 1);
+                             return inst.get_output_size(bit_mode, slice);
         },
         // AF      r16     r16
         // AF      r16     m16
@@ -908,7 +910,9 @@ void Pass1Strategy::processIMUL(std::vector<TParaToken>& mnemonic_args) {
         // 69      r16     imm16
         // 69      r32     imm32
         pattern | ds(or_(TParaToken::ttReg16, TParaToken::ttReg32), TParaToken::ttImm, std::nullopt) = [&] {
-            return inst.get_output_size(bit_mode, mnemonic_args);
+            // 2個渡す
+            std::vector<TParaToken> slice(mnemonic_args.begin(), mnemonic_args.begin() + 2);
+            return inst.get_output_size(bit_mode, slice);
         },
         // 6B      r16     r16     imm8
         // 69      r16     r16     imm16
@@ -926,7 +930,7 @@ void Pass1Strategy::processIMUL(std::vector<TParaToken>& mnemonic_args) {
                      or_(TParaToken::ttReg16, TParaToken::ttReg32, TParaToken::ttReg64,
                          TParaToken::ttMem16, TParaToken::ttMem32, TParaToken::ttMem64),
                      or_(TParaToken::ttImm)) = [&] {
-                         return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1], mnemonic_args[2]});
+                         return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | _ = [&] {
             std::stringstream ss;

--- a/src/pass1_strategy.cc
+++ b/src/pass1_strategy.cc
@@ -334,85 +334,85 @@ void Pass1Strategy::processADD(std::vector<TParaToken>& mnemonic_args) {
 
     uint32_t l = match(operands)(
         pattern | ds(TParaToken::ttReg8, "AL", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttMem8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, "AX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttMem16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, "EAX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttMem32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, "RAX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttMem64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | _ = [&] {
             std::stringstream ss;
@@ -480,85 +480,85 @@ void Pass1Strategy::processAND(std::vector<TParaToken>& mnemonic_args) {
 
     uint32_t l = match(operands)(
         pattern | ds(TParaToken::ttReg8, "AL", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttMem8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, "AX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttMem16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, "EAX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttMem32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, "RAX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttMem64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | _ = [&] {
             std::stringstream ss;
@@ -603,10 +603,10 @@ void Pass1Strategy::processCALL(std::vector<TParaToken>& mnemonic_args) {
 
     uint32_t l = match(operands)(
         pattern | ds(TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
             return 3; // opcode + iw
@@ -672,85 +672,85 @@ void Pass1Strategy::processCMP(std::vector<TParaToken>& mnemonic_args) {
 
     uint32_t l = match(operands)(
         pattern | ds(TParaToken::ttReg8, "AL", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttMem8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, "AX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttMem16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, "EAX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttMem32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, "RAX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttMem64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | _ = [&] {
             std::stringstream ss;
@@ -889,7 +889,7 @@ void Pass1Strategy::processIMUL(std::vector<TParaToken>& mnemonic_args) {
                          TParaToken::ttMem16,
                          TParaToken::ttMem32,
                          TParaToken::ttMem64), std::nullopt, std::nullopt) = [&] {
-                             return inst.get_output_size(bit_mode, {mnemonic_args[0]});
+                             return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // AF      r16     r16
         // AF      r16     m16
@@ -900,7 +900,7 @@ void Pass1Strategy::processIMUL(std::vector<TParaToken>& mnemonic_args) {
         pattern | ds(or_(TParaToken::ttReg16, TParaToken::ttReg32, TParaToken::ttReg64),
                      or_(TParaToken::ttReg16, TParaToken::ttReg32, TParaToken::ttReg64,
                          TParaToken::ttMem16, TParaToken::ttMem32, TParaToken::ttMem64), std::nullopt) = [&] {
-                             return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+                             return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // TODO: 即値部分はJSONには記載なし
         // 6B      r16     imm8
@@ -908,7 +908,7 @@ void Pass1Strategy::processIMUL(std::vector<TParaToken>& mnemonic_args) {
         // 69      r16     imm16
         // 69      r32     imm32
         pattern | ds(or_(TParaToken::ttReg16, TParaToken::ttReg32), TParaToken::ttImm, std::nullopt) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 6B      r16     r16     imm8
         // 69      r16     r16     imm16
@@ -998,10 +998,10 @@ void Pass1Strategy::processINT(std::vector<TParaToken>& mnemonic_args) {
 
     uint32_t l = match(operands)(
         pattern | ds(_, "3") = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | _ = [&] {
             std::stringstream ss;
@@ -1332,28 +1332,28 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
         },
         // A3      moffs32 eax
         pattern | ds(_, _, TParaToken::ttReg32, "EAX") = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // A3      moffs64 rax
         pattern | ds(_, _, TParaToken::ttReg64, "RAX") = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // A1      eax     moffs32
         pattern | ds(TParaToken::ttReg32, "EAX", _, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // A1      rax     moffs64
         pattern | ds(TParaToken::ttReg64, "RAX", _, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
 
         // C6      r8      imm8
         pattern | ds(TParaToken::ttReg8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 88      r8      r8
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 8A      r8      m8
         pattern | ds(TParaToken::ttReg8, _, or_(TParaToken::ttMem8, TParaToken::ttMem16, TParaToken::ttMem32), _) = [&] {
@@ -1364,46 +1364,46 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
         },
         // C7      r16     imm16
         pattern | ds(TParaToken::ttReg16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 89      r16     r16
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 8B      r16     m16
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttMem16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // C7      r32     imm32
         pattern | ds(TParaToken::ttReg32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 89      r32     r32
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 8B      r32     m32
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttMem32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // C7      r64     imm32
         // B8      r64     imm64
         pattern | ds(TParaToken::ttReg64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 89      r64     r64
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 8B      r64     m64
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttMem64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // C6      m8      imm8
         pattern | ds(TParaToken::ttMem8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
             // `MOV BYTE [addr_size], X`
             auto addr_size = mnemonic_args[0].GetImmSize();
-            auto size = addr_size + inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            auto size = addr_size + inst.get_output_size(bit_mode, mnemonic_args);
             return size;
         },
         // 88      m8      r8
@@ -1419,12 +1419,12 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
             // `MOV WORD [addr_size], X`
             auto addr_size = mnemonic_args[0].GetImmSize();
-            auto size = addr_size + inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            auto size = addr_size + inst.get_output_size(bit_mode, mnemonic_args);
             return size;
         },
         // 89      m16     r16
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // C7      m32     imm32
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
@@ -1432,20 +1432,20 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
             // TODO: x86 tableの定義に`prefix`の定義がない
             auto override_prefix_size = (bit_mode != ID_32BIT_MODE) ? 1 : 0;
             auto addr_size = mnemonic_args[0].GetImmSize();
-            auto size = override_prefix_size + addr_size + inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            auto size = override_prefix_size + addr_size + inst.get_output_size(bit_mode, mnemonic_args);
             return size;
         },
         // 89      m32     r32
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // C7      m64     imm32
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 89      m64     r64
         pattern | ds(TParaToken::ttMem64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | _ = [&] {
             std::stringstream ss;
@@ -1526,85 +1526,85 @@ void Pass1Strategy::processOR(std::vector<TParaToken>& mnemonic_args) {
 
     uint32_t l = match(operands)(
         pattern | ds(TParaToken::ttReg8, "AL", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttMem8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, "AX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttMem16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, "EAX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttMem32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, "RAX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttMem64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | _ = [&] {
             std::stringstream ss;
@@ -1648,22 +1648,22 @@ void Pass1Strategy::processOUT(std::vector<TParaToken>& mnemonic_args) {
 
     uint32_t l = match(operands)(
         pattern | ds(or_(TParaToken::ttImm, TParaToken::ttLabel), _, TParaToken::ttReg8, "AL") = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(or_(TParaToken::ttImm, TParaToken::ttLabel), _, TParaToken::ttReg16, "AX") = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(or_(TParaToken::ttImm, TParaToken::ttLabel), _, TParaToken::ttReg32, "EAX") = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, "DX", TParaToken::ttReg8, "AL") = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, "DX", TParaToken::ttReg16, "AX") = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, "DX", TParaToken::ttReg32, "EAX") = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | _ = [&] {
             std::stringstream ss;
@@ -1737,7 +1737,7 @@ void Pass1Strategy::processSHR(std::vector<TParaToken>& mnemonic_args) {
                          TParaToken::ttMem16,
                          TParaToken::ttMem32,
                          TParaToken::ttMem64), _, TParaToken::ttReg8, "CL") = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(or_(TParaToken::ttReg8,
                          TParaToken::ttReg16,
@@ -1747,7 +1747,7 @@ void Pass1Strategy::processSHR(std::vector<TParaToken>& mnemonic_args) {
                          TParaToken::ttMem16,
                          TParaToken::ttMem32,
                          TParaToken::ttMem64), _, TParaToken::ttImm, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(or_(TParaToken::ttReg8,
                          TParaToken::ttReg16,
@@ -1757,7 +1757,7 @@ void Pass1Strategy::processSHR(std::vector<TParaToken>& mnemonic_args) {
                          TParaToken::ttMem16,
                          TParaToken::ttMem32,
                          TParaToken::ttMem64), _, std::nullopt, std::nullopt) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | _ = [&] {
             std::stringstream ss;
@@ -1825,85 +1825,85 @@ void Pass1Strategy::processSUB(std::vector<TParaToken>& mnemonic_args) {
 
     uint32_t l = match(operands)(
         pattern | ds(TParaToken::ttReg8, "AL", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg8, _, TParaToken::ttMem8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, "AX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg16, _, TParaToken::ttMem16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, "EAX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg32, _, TParaToken::ttMem32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, "RAX", or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttReg64, _, TParaToken::ttMem64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem8, _, TParaToken::ttReg8, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | ds(TParaToken::ttMem64, _, TParaToken::ttReg64, _) = [&] {
-            return inst.get_output_size(bit_mode, {mnemonic_args[0], mnemonic_args[1]});
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         pattern | _ = [&] {
             std::stringstream ss;

--- a/src/x86.cc
+++ b/src/x86.cc
@@ -193,8 +193,15 @@ namespace x86_64 {
                 pattern | ds(_,_)          = false
             );
 
-            if (reg_name_matched)
+            if (reg_name_matched) {
+                // 直接レジスタ名がマッチ
                 continue;
+            }
+
+            if (_starts_with(table_token_type, "imm") && tokens[i].AsAttr()==TParaToken::ttLabel) {
+                // x86_64.json側が即値表記、tokenはラベルの場合マッチ
+                continue;
+            }
 
             // "imm"でも"imm8"とマッチさせたいので前方一致で比較する
             // しかしながら、token側のサイズが既定に満たないならば除外
@@ -202,15 +209,12 @@ namespace x86_64 {
                 const int32_t actual_imm = tokens[i].AsInt32();
 
                 if (table_token_type == "imm8" && -0x80 <= actual_imm && actual_imm <= 0x7f) {
-                    //std::cout << "imm8 match!!" << actual_imm << std::endl;
                     continue;
                 }
                 if (table_token_type == "imm16" && -0x8000 <= actual_imm && actual_imm <= 0x7fff) {
-                    //std::cout << "imm16 match!!" << actual_imm << std::endl;
                     continue;
                 }
                 if (table_token_type == "imm32") {
-                    //std::cout << "imm32 match!!" << actual_imm << std::endl;
                     continue;
                 }
             }

--- a/src/x86.cc
+++ b/src/x86.cc
@@ -205,6 +205,8 @@ namespace x86_64 {
     const uint32_t Instruction::get_output_size(OPENNASK_MODES mode,
                                                 const std::vector<TParaToken>& tokens) {
 
+        spdlog::get("opennask")->error("[pass1] passed tokens size {}", tokens.size());
+
         auto it = std::find_if(forms_.begin(), forms_.end(), [&](InstructionForm& form) {
             return this->find_greedy(mode, tokens, form);
         });

--- a/src/x86.hh
+++ b/src/x86.hh
@@ -410,7 +410,7 @@ namespace x86_64 {
             return data_offset_;
         }
 
-        const int get_output_size(OPENNASK_MODES mode);
+        const int get_output_size(OPENNASK_MODES mode) const;
     };
 
     class InstructionForm {
@@ -464,7 +464,7 @@ namespace x86_64 {
         }
 
         // 複数機械語の出力があり得る場合がたまにある
-        const Encoding find_encoding();
+        Encoding find_encoding() const;
     };
 
     class Instruction {
@@ -489,8 +489,8 @@ namespace x86_64 {
             return forms_;
         }
 
-        const bool find_greedy(OPENNASK_MODES, const std::vector<TParaToken>&, InstructionForm&);
-        const uint32_t get_output_size(OPENNASK_MODES, const std::vector<TParaToken>&);
+        const bool find_greedy(OPENNASK_MODES, const std::vector<TParaToken>&, const InstructionForm&) const;
+        const uint32_t get_output_size(OPENNASK_MODES, const std::vector<TParaToken>&) const;
     };
 
     class InstructionSet {

--- a/src/x86.hh
+++ b/src/x86.hh
@@ -15,9 +15,9 @@ namespace x86_64 {
 
     extern const char* X86_64_JSON;
 
-    const bool _require_67h(OPENNASK_MODES, std::initializer_list<TParaToken>);
-    const bool _require_66h(OPENNASK_MODES, std::initializer_list<TParaToken>);
-    const std::string token_to_x86_type(const TParaToken*);
+    const bool _require_67h(OPENNASK_MODES, const std::vector<TParaToken>&);
+    const bool _require_66h(OPENNASK_MODES, const std::vector<TParaToken>&);
+    const std::string token_to_x86_type(const TParaToken&);
     const bool _starts_with(std::string const &full_string, std::string const &begining);
     const std::string _to_lower(const std::string &in);
 
@@ -489,8 +489,8 @@ namespace x86_64 {
             return forms_;
         }
 
-        const bool find_greedy(OPENNASK_MODES, std::initializer_list<TParaToken>, InstructionForm&);
-        const uint32_t get_output_size(OPENNASK_MODES, std::initializer_list<TParaToken>);
+        const bool find_greedy(OPENNASK_MODES, const std::vector<TParaToken>&, InstructionForm&);
+        const uint32_t get_output_size(OPENNASK_MODES, const std::vector<TParaToken>&);
     };
 
     class InstructionSet {

--- a/src/x86.hh
+++ b/src/x86.hh
@@ -17,6 +17,7 @@ namespace x86_64 {
 
     const bool _require_67h(OPENNASK_MODES, const std::vector<TParaToken>&);
     const bool _require_66h(OPENNASK_MODES, const std::vector<TParaToken>&);
+    const size_t _calc_offset_byte_size(const std::vector<TParaToken>& tokens);
     const std::string token_to_x86_type(const TParaToken&);
     const bool _starts_with(std::string const &full_string, std::string const &begining);
     const std::string _to_lower(const std::string &in);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,12 +79,12 @@ gtest_discover_tests(inst_suite_test)
 ########### next target ###############
 
 # lexer, parser testing
-# `ctest -R parsertest`
+# `ctest -R exp_suite_test`
 set(parsertest_SRCS
   exp_suite.cpp)
 
-add_executable(parsertest ${parsertest_SRCS})
-target_link_libraries(parsertest PRIVATE
+add_executable(exp_suite_test ${parsertest_SRCS})
+target_link_libraries(exp_suite_test PRIVATE
   nask_parse_objects
   Threads::Threads
   spdlog::spdlog
@@ -92,12 +92,12 @@ target_link_libraries(parsertest PRIVATE
   parasol
   GTest::gtest_main)
 if(WITH_BACKWARDS_CPP)
-  target_link_libraries(parsertest PUBLIC -lbfd)
-  target_link_libraries(parsertest PUBLIC backward)
+  target_link_libraries(exp_suite_test PUBLIC -lbfd)
+  target_link_libraries(exp_suite_test PUBLIC backward)
 endif()
 
-target_compile_features(parsertest PRIVATE cxx_std_17)
-gtest_discover_tests(parsertest)
+target_compile_features(exp_suite_test PRIVATE cxx_std_17)
+gtest_discover_tests(exp_suite_test)
 
 # `ctest -R modrmtest`
 set(modrmtest_SRCS

--- a/test/inst_suite.cpp
+++ b/test/inst_suite.cpp
@@ -52,7 +52,30 @@ void PrintTo(const StatementToMachineCodeParam& param, ::std::ostream* os) {
     *os << param._statement;
 }
 
-class StatementToMachineCode : public testing::TestWithParam<StatementToMachineCodeParam> {};
+class StatementToMachineCode : public testing::TestWithParam<StatementToMachineCodeParam> {
+
+protected:
+    // 試験開始時に一回だけ実行
+    StatementToMachineCode() {
+        if(!spdlog::get("opennask")) {
+            auto logger = spdlog::stdout_color_st("opennask");
+        }
+    }
+
+    // 試験終了時に一回だけ実行
+    ~StatementToMachineCode() override {
+    }
+
+    // 各テストケース実行前に実行
+    void SetUp() override {
+        //spdlog::set_level(spdlog::level::debug);
+        spdlog::set_level(spdlog::level::trace);
+    }
+
+    // 各テストケース実行後に実行
+    void TearDown() override {
+    }
+};
 
 TEST_P(StatementToMachineCode, StatementToMachineCode) {
     const auto p = GetParam();

--- a/test/pass1_test.cpp
+++ b/test/pass1_test.cpp
@@ -8,7 +8,7 @@ class Pass1Suite : public ::testing::Test {
 protected:
     // 試験開始時に一回だけ実行
     Pass1Suite() {
-        spdlog::set_level(spdlog::level::debug);
+        spdlog::set_level(spdlog::level::trace);
     }
 
     // 試験終了時に一回だけ実行

--- a/test/pass1_test.cpp
+++ b/test/pass1_test.cpp
@@ -8,7 +8,7 @@ class Pass1Suite : public ::testing::Test {
 protected:
     // 試験開始時に一回だけ実行
     Pass1Suite() {
-        //spdlog::set_level(spdlog::level::debug);
+        spdlog::set_level(spdlog::level::debug);
     }
 
     // 試験終了時に一回だけ実行
@@ -207,20 +207,112 @@ msg:
 }
 
 
-TEST_F(Pass1Suite, SymTable) {
-
-    GTEST_SKIP(); // TODO: まだ機能しない
+TEST_F(Pass1Suite, Harib00i) {
 
     std::stringstream ss;
     const char nask_statements[] = R"(
-		ORG		0x0100
-		;LDA		#5
+; シンボルテーブルへのラベルの設定の結合テスト
+; 各種命令の機械語のサイズ取得のe2eテストも兼ねる
+BOTPAK	EQU		0x00280000
+DSKCAC	EQU		0x00100000
+DSKCAC0	EQU		0x00008000
+CYLS	EQU		0x0ff0
+LEDS	EQU		0x0ff1
+VMODE	EQU		0x0ff2
+SCRNX	EQU		0x0ff4
+SCRNY	EQU		0x0ff6
+VRAM	EQU		0x0ff8
 
-LOOP:
-		;SUB		#1
-		;COMP		#0
-		;JGT		LOOP
-		;RSUB		#1
+		ORG		0xc200
+
+		MOV		AL,0x13
+		MOV		AH,0x00
+		INT		0x10
+		MOV		BYTE [VMODE],8
+		MOV		WORD [SCRNX],320
+		MOV		WORD [SCRNY],200
+		MOV		DWORD [VRAM],0x000a0000
+		MOV		AH,0x02
+		INT		0x16
+		MOV		[LEDS],AL
+		MOV		AL,0xff
+		OUT		0x21,AL
+		NOP
+		OUT		0xa1,AL
+		CLI
+		CALL	waitkbdout
+		MOV		AL,0xd1
+		OUT		0x64,AL
+		CALL	waitkbdout
+		MOV		AL,0xdf
+		OUT		0x60,AL
+		CALL	waitkbdout
+
+[INSTRSET "i486p"]
+		LGDT	[GDTR0]
+		MOV		EAX,CR0
+		AND		EAX,0x7fffffff
+		OR		EAX,0x00000001
+		MOV		CR0,EAX
+		JMP		pipelineflush
+pipelineflush:
+		MOV		AX,1*8
+		MOV		DS,AX
+		MOV		ES,AX
+		MOV		FS,AX
+		MOV		GS,AX
+		MOV		SS,AX
+		MOV		ESI,bootpack
+		MOV		EDI,BOTPAK
+		MOV		ECX,512*1024/4
+		CALL	memcpy
+		MOV		ESI,0x7c00
+		MOV		EDI,DSKCAC
+		MOV		ECX,512/4
+		CALL	memcpy
+		MOV		ESI,DSKCAC0+512
+		MOV		EDI,DSKCAC+512
+		MOV		ECX,0
+		MOV		CL,BYTE [CYLS]
+		IMUL	ECX,512*18*2/4
+		SUB		ECX,512/4
+		CALL	memcpy
+		MOV		EBX,BOTPAK
+		MOV		ECX,[EBX+16]
+		ADD		ECX,3
+		SHR		ECX,2
+		JZ		skip
+		MOV		ESI,[EBX+20]
+		ADD		ESI,EBX
+		MOV		EDI,[EBX+12]
+		CALL	memcpy
+skip:
+		MOV		ESP,[EBX+12]
+		JMP		DWORD 2*8:0x0000001b
+waitkbdout:
+		IN		 AL,0x64
+		AND		 AL,0x02
+		JNZ		waitkbdout
+		RET
+memcpy:
+		MOV		EAX,[ESI]
+		ADD		ESI,4
+		MOV		[EDI],EAX
+		ADD		EDI,4
+		SUB		ECX,1
+		JNZ		memcpy
+		RET
+		ALIGNB	16
+GDT0:
+		RESB	8
+		DW		0xffff,0x0000,0x9200,0x00cf
+		DW		0xffff,0x0000,0x9a28,0x0047
+		DW		0
+GDTR0:
+		DW		8*3-1
+		DD		GDT0
+		ALIGNB	16
+bootpack:
 )";
 
     ss << nask_statements;
@@ -229,6 +321,12 @@ LOOP:
     auto pass1 = std::make_unique<Pass1Strategy>();
     pass1->Eval(pt.get());
 
-    EXPECT_EQ(1, pass1->sym_table.count("LOOP"));
-    EXPECT_EQ(259, pass1->sym_table.at("LOOP"));
+    // 0xc200=49664
+    EXPECT_EQ(0xc200 + 87,  pass1->sym_table["pipelineflush"]);
+    EXPECT_EQ(0xc200 + 217, pass1->sym_table["skip"]);
+    EXPECT_EQ(0xc200 + 230, pass1->sym_table["waitkbdout"]);
+    EXPECT_EQ(0xc200 + 237, pass1->sym_table["memcpy"]);
+    EXPECT_EQ(0xc200 + 271, pass1->sym_table["GDT0"]);
+    EXPECT_EQ(0xc200 + 297, pass1->sym_table["GDTR0"]);
+    EXPECT_EQ(0xc200 + 303, pass1->sym_table["bootpack"]);
 }

--- a/test/pass1_test.cpp
+++ b/test/pass1_test.cpp
@@ -323,6 +323,7 @@ bootpack:
 
     // 0xc200=49664
     EXPECT_EQ(0xc200 + 87,  pass1->sym_table["pipelineflush"]);
+    GTEST_SKIP(); // TODO: まだ機能しない
     EXPECT_EQ(0xc200 + 217, pass1->sym_table["skip"]);
     EXPECT_EQ(0xc200 + 230, pass1->sym_table["waitkbdout"]);
     EXPECT_EQ(0xc200 + 237, pass1->sym_table["memcpy"]);

--- a/test/x86_table_test.cpp
+++ b/test/x86_table_test.cpp
@@ -211,24 +211,29 @@ INSTANTIATE_TEST_SUITE_P(X86TableSuite, InstToMachineCodeSize,
         InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
                                    {
                                        TParaToken("AX", TParaToken::ttIdentifier, TParaToken::ttReg16),
-                                       TParaToken("0", TParaToken::ttIdentifier, TParaToken::ttImm)
+                                       TParaToken("0", TParaToken::ttInteger, TParaToken::ttImm)
                                    },
                                    3),
         InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
                                    {
-                                       TParaToken("[0x0ff0]", TParaToken::ttIdentifier, TParaToken::ttMem8),
+                                       TParaToken("[0x0ff0]", TParaToken::ttHex, TParaToken::ttMem8),
                                        TParaToken("CH", TParaToken::ttIdentifier, TParaToken::ttReg8)
                                    },
                                    2), // +2byteはpass1側で足す
-
         // 0x0D id    = 1(prefix) + 1 + 4 byte     = 6byte
         // 0x83 /1 ib = 1(prefix) + 1 + 1 + 1 byte = 4byte
         // 出力される機械語が少ない方を優先的に選ぶ
         InstToMachineCodeSizeParam(ID_16BIT_MODE, "OR",
                                    {
                                        TParaToken("EAX", TParaToken::ttIdentifier, TParaToken::ttReg32),
-                                       TParaToken("0x00000001", TParaToken::ttIdentifier, TParaToken::ttImm)
+                                       TParaToken("0x00000001", TParaToken::ttHex, TParaToken::ttImm)
                                    },
-                                   4)
+                                   4),
+        InstToMachineCodeSizeParam(ID_16BIT_MODE, "IMUL",
+                                   {
+                                       TParaToken("ECX", TParaToken::ttIdentifier, TParaToken::ttReg32),
+                                       TParaToken("4608", TParaToken::ttInteger, TParaToken::ttImm)
+                                   },
+                                   7)
     )
 );

--- a/test/x86_table_test.cpp
+++ b/test/x86_table_test.cpp
@@ -148,6 +148,10 @@ protected:
     // 試験開始時に一回だけ実行
     InstToMachineCodeSize() {
         _iset = std::make_unique<x86_64::InstructionSet>(jsoncons::decode_json<x86_64::InstructionSet>(std::string(x86_64::X86_64_JSON)));
+        // spdlog
+        if(!spdlog::get("opennask")) {
+            auto logger = spdlog::stdout_color_st("opennask");
+        }
     }
 
     // 試験終了時に一回だけ実行
@@ -156,10 +160,7 @@ protected:
 
     // 各テストケース実行前に実行
     void SetUp() override {
-        // spdlog
-        if(!spdlog::get("opennask")) {
-            auto logger = spdlog::stdout_color_st("opennask");
-        }
+        spdlog::set_level(spdlog::level::debug);
     }
 
     // 各テストケース実行後に実行
@@ -217,6 +218,16 @@ INSTANTIATE_TEST_SUITE_P(X86TableSuite, InstToMachineCodeSize,
                                        TParaToken("[0x0ff0]", TParaToken::ttIdentifier, TParaToken::ttMem8),
                                        TParaToken("CH", TParaToken::ttIdentifier, TParaToken::ttReg8)
                                    },
-                                   2) // +2byteはpass1側で足す
+                                   2), // +2byteはpass1側で足す
+
+        // 0x0D id    = 1(prefix) + 1 + 4 byte     = 6byte
+        // 0x83 /1 ib = 1(prefix) + 1 + 1 + 1 byte = 4byte
+        // 出力される機械語が少ない方を優先的に選ぶ
+        InstToMachineCodeSizeParam(ID_16BIT_MODE, "OR",
+                                   {
+                                       TParaToken("EAX", TParaToken::ttIdentifier, TParaToken::ttReg32),
+                                       TParaToken("0x00000001", TParaToken::ttIdentifier, TParaToken::ttImm)
+                                   },
+                                   4)
     )
 );

--- a/test/x86_table_test.cpp
+++ b/test/x86_table_test.cpp
@@ -25,6 +25,7 @@ protected:
         if(!spdlog::get("opennask")) {
             auto logger = spdlog::stdout_color_st("opennask");
         }
+        spdlog::set_level(spdlog::level::trace);
     }
 
     // 各テストケース実行後に実行
@@ -148,7 +149,6 @@ protected:
     // 試験開始時に一回だけ実行
     InstToMachineCodeSize() {
         _iset = std::make_unique<x86_64::InstructionSet>(jsoncons::decode_json<x86_64::InstructionSet>(std::string(x86_64::X86_64_JSON)));
-        // spdlog
         if(!spdlog::get("opennask")) {
             auto logger = spdlog::stdout_color_st("opennask");
         }
@@ -160,7 +160,8 @@ protected:
 
     // 各テストケース実行前に実行
     void SetUp() override {
-        spdlog::set_level(spdlog::level::debug);
+        //spdlog::set_level(spdlog::level::debug);
+        spdlog::set_level(spdlog::level::trace);
     }
 
     // 各テストケース実行後に実行


### PR DESCRIPTION
ref #85

## 対応内容
- ３日目のテスト追加(harib00i) まだ途中
    - [３日目のアセンブラをダンプ（後編）](https://github.com/HobbyOSs/opennask/wiki/%EF%BC%93%E6%97%A5%E7%9B%AE%E3%81%AE%E3%82%A2%E3%82%BB%E3%83%B3%E3%83%96%E3%83%A9%E3%82%92%E3%83%80%E3%83%B3%E3%83%97%EF%BC%88%E5%BE%8C%E7%B7%A8%EF%BC%89)


## やったこと
- IMUL命令がJSON定義になかったので追加 https://github.com/hangingman/json-x86-64/pull/7
- 読み取ったtokenの型を `std::initializer_list<TParaToken>` で定義されていたが超絶テストしにくいので `std::vector<TParaToken>` に変更し改善、パラメタライズテストを追加