### PR TITLE
EBNF版のnask_parseで実装を置き換え(3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,15 +6,16 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 project(root)
 
 #-----------------------------------------------------------------------
-# Dev macro
+# Dev macro (uncommend if you want to use)
 #
-
 #set(CMAKE_BUILD_TYPE "Debug" CACHE INTERNAL "cmake build type")
 #set(CMAKE_C_COMPILER "/usr/bin/clang" CACHE INTERNAL "clang compiler")
 #set(CMAKE_CXX_COMPILER "/usr/bin/clang++" CACHE INTERNAL "clang++ compiler")
 
+#-----------------------------------------------------------------------
+# tools
+#
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
-
 set(WINE "/usr/bin/wine" CACHE INTERNAL "")
 set(WINE_NASK "~/.wine/drive_c/MinGW/msys/1.0/bin/nask.exe" CACHE INTERNAL "")
 set(OD "od" CACHE INTERNAL "")

--- a/src/bin_util.cc
+++ b/src/bin_util.cc
@@ -20,6 +20,22 @@ const std::array<uint8_t, 4> BinUtil::LongAsDword(const long dword) {
     };
 }
 
+template<typename T>
+const std::string BinUtil::int_to_hex(T i) {
+    std::stringstream stream;
+    stream << "0x"
+           << std::setfill ('0') << std::setw(sizeof(T)*2)
+           << std::hex << i;
+    return stream.str();
+}
+
+template const std::string BinUtil::int_to_hex(int8_t i);
+template const std::string BinUtil::int_to_hex(int16_t i);
+template const std::string BinUtil::int_to_hex(int32_t i);
+template const std::string BinUtil::int_to_hex(uint8_t i);
+template const std::string BinUtil::int_to_hex(uint16_t i);
+template const std::string BinUtil::int_to_hex(uint32_t i);
+
 const std::string BinUtil::bytes_to_hex(std::vector<uint8_t>& bytes) {
     std::vector<std::string> debug_args = {};
     std::transform(bytes.begin(), bytes.end(),

--- a/src/bin_util.hh
+++ b/src/bin_util.hh
@@ -21,6 +21,8 @@ public:
     const std::array<uint8_t, NASK_WORD> IntAsWord(const int);
     const std::array<uint8_t, NASK_DWORD> LongAsDword(const long);
 
+    template<typename T>
+    const std::string int_to_hex(T i);
     const std::string bytes_to_hex(std::vector<uint8_t>& bytes);
     const std::string join(std::vector<std::string>&, const std::string& = "");
 

--- a/src/front_end/front_inst.cc
+++ b/src/front_end/front_inst.cc
@@ -360,25 +360,20 @@ void FrontEnd::processLGDT(std::vector<TParaToken>& mnemonic_args) {
         using namespace asmjit;
 
         if (src.AsAttr() == TParaToken::ttImm) {
-            auto mem = x86::Mem(src.AsInt32());
-            // TODO: 自力実装
+            auto src_mem = "[" + src.AsString() + "]";
             a.db(0x0f);
             a.db(0x01);
-            a.db(0x00);
-            a.db(0x00);
-            a.db(0x00);
+            a.db(ModRM::generate_modrm(ModRM::REG_REG, src_mem, ModRM::SLASH_2));
+            a.dw(src.AsInt32());
         } else if (src.AsAttr() == TParaToken::ttLabel) {
             CodeBuffer& buf = code_.textSection()->buffer();
             const std::string label = src.AsString();
-            const auto label_address = sym_table.at(label);
-            const int32_t jmp_offset = label_address - (dollar_position + buf.size());
-            auto mem = x86::Mem(jmp_offset);
-            // TODO: 自力実装
+            const auto label_address = static_cast<uint16_t>(sym_table.at(label));
+            auto src_mem = "[" + int_to_hex(label_address) + "]";
             a.db(0x0f);
             a.db(0x01);
-            a.db(0x00);
-            a.db(0x00);
-            a.db(0x00);
+            a.db(ModRM::generate_modrm(ModRM::REG_REG, src_mem, ModRM::SLASH_2));
+            a.dw(label_address);
         } else {
             throw std::runtime_error("LGDT, Not implemented or not matched!!!");
         }

--- a/src/front_end/front_inst.cc
+++ b/src/front_end/front_inst.cc
@@ -926,6 +926,7 @@ void PrefixInfo::set(OPENNASK_MODES bit_mode, TParaToken& dst) {
     // Operand size prefix
     require_66h = match(bit_mode)(
         pattern | ID_16BIT_MODE | when(dst_attr == TParaToken::ttReg32) = true,
+        pattern | ID_16BIT_MODE | when(dst_attr == TParaToken::ttMem32) = true,
         pattern | ID_16BIT_MODE = false,
         pattern | _ = false
     );
@@ -949,6 +950,7 @@ void PrefixInfo::set(OPENNASK_MODES bit_mode, TParaToken& dst, TParaToken& src) 
     // Operand size prefix
     require_66h = match(bit_mode)(
         pattern | ID_16BIT_MODE | when(dst_attr == TParaToken::ttReg32||src_attr == TParaToken::ttReg32) = true,
+        pattern | ID_16BIT_MODE | when(dst_attr == TParaToken::ttMem32||src_attr == TParaToken::ttMem32) = true,
         pattern | ID_16BIT_MODE = false,
         pattern | _ = false
     );

--- a/src/front_end/front_inst.cc
+++ b/src/front_end/front_inst.cc
@@ -482,7 +482,6 @@ void FrontEnd::processMOV(std::vector<TParaToken>& mnemonic_args) {
             },
 
             // 89      r32     r32
-
             // 8B      r32     m32
             pattern | ds(TParaToken::ttReg32, _, TParaToken::ttMem32, _) = [&] {
                 a.mov(dst.AsAsmJitGpd(), src.AsMem() );

--- a/src/front_end/front_inst_jmp.cc
+++ b/src/front_end/front_inst_jmp.cc
@@ -56,7 +56,9 @@ void FrontEnd::processCALL(std::vector<TParaToken>& mnemonic_args) {
                 CodeBuffer& buf = code_.textSection()->buffer();
                 const std::string label = arg.AsString();
                 const auto label_address = sym_table.at(label);
-                const int32_t jmp_offset = label_address - (dollar_position + buf.size());
+                // 相対ジャンプのオフセット =
+                //   対象の絶対アドレス - ( ORGのポジション + ここまでで生成した機械語サイズ ) - CALL命令自体の機械語サイズ
+                const int32_t jmp_offset = label_address - (dollar_position + buf.size()) - 3;
                 auto asmjit_label = code_.labelByName(label.c_str());
                 if( ! asmjit_label.isValid() ) {
                     a.newNamedLabel(label.c_str());

--- a/src/front_end/front_inst_pseudo.cc
+++ b/src/front_end/front_inst_pseudo.cc
@@ -74,13 +74,11 @@ void FrontEnd::processDD(std::vector<TParaToken>& mnemonic_args) {
             if (e.IsInteger() || e.IsHex()) {
                 a.dd(e.AsInt32());
             } else if (e.AsAttr() == TParaToken::ttLabel) {
-                // TODO: スタブ
                 using namespace asmjit;
                 CodeBuffer& buf = code_.textSection()->buffer();
                 const std::string label = e.AsString();
-                const auto label_address = sym_table.at(label);
-                const int16_t jmp_offset = label_address - (dollar_position + buf.size());
-                a.dw(jmp_offset);
+                const auto label_address = static_cast<uint16_t>(sym_table.at(label));
+                a.dw(label_address);
             } else if (e.IsIdentifier()) {
                 throw std::runtime_error("not implemented");
             }

--- a/src/front_end/front_memory_addr.cc
+++ b/src/front_end/front_memory_addr.cc
@@ -63,6 +63,7 @@ void FrontEnd::visitDirect(Direct *direct) {
             t.SetMem(mem);
         }
     );
+
     this->ctx.pop();
     this->ctx.push(t);
 };
@@ -138,7 +139,7 @@ void FrontEnd::visitDatatypeExp(DatatypeExp *datatype_exp) {
         pattern | "WORD" = [&]{ right.SetAttribute(TParaToken::ttMem16); },
         pattern | "DWORD" = [&]{ right.SetAttribute(TParaToken::ttMem32); },
         pattern | _ = [&] {
-            throw std::runtime_error("datatype, Not implemented or not matched!!!");
+            throw std::runtime_error("[pass2] datatype, Not implemented or not matched!!!");
         }
     );
 

--- a/src/para_token.hh
+++ b/src/para_token.hh
@@ -112,7 +112,7 @@ public:
     ~TParaToken();
     void SetAttribute();
     void SetAttribute(TIdentiferAttribute attr);
-    void SetMem(const asmjit::x86::Mem& mem, const int16_t _segment = 0);
+    TParaToken& SetMem(const asmjit::x86::Mem& mem, const int16_t _segment = 0);
 
     std::string to_string() const;
     TParaToken& operator=(const TParaToken& token);
@@ -133,6 +133,7 @@ public:
     std::string AsString(void) const;
     asmjit::x86::Mem& AsMem(void) const;
     bool IsMem(void) const;
+    bool HasMemBase(void) const;
     int16_t AsSegment(void) const;
 
     // asmjit provides following datatype
@@ -176,7 +177,9 @@ public:
     std::array<uint8_t, 1> AsUInt8t(void) const noexcept(false);
     std::array<uint8_t, 2> AsUInt16t(void) const noexcept(false);
     std::array<uint8_t, 4> AsUInt32t(void) const noexcept(false);
+    size_t GetOffsetSize() const;
     size_t GetImmSize() const;
+
     TTokenType AsType() const;
     TIdentiferAttribute AsAttr() const;
     TParaToken& RemoveQuotation(char quoter = '\0');

--- a/src/pass1_strategy.cc
+++ b/src/pass1_strategy.cc
@@ -1406,25 +1406,19 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
         // C6      m8      imm8
         pattern | ds(TParaToken::ttMem8, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
             // `MOV BYTE [addr_size], X`
-            auto addr_size = mnemonic_args[0].GetImmSize();
-            auto size = addr_size + inst.get_output_size(bit_mode, mnemonic_args);
-            return size;
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 88      m8      r8
-        // 88      m16     r8 (m16の場合下位8ビットが使われる)
+        // ex) `MOV [0x0ff0],CH`
+        // カッコ内部のアドレスの大きさに関わらずdstのオペランドはm8扱いになる(転送元レジスタによって決まる)
         pattern | ds(or_(TParaToken::ttMem8, TParaToken::ttMem16), _, TParaToken::ttReg8, _) = [&] {
-            auto token = TParaToken(mnemonic_args[0]);
-            token.SetAttribute(TParaToken::ttMem8);
-            // `MOV [0x0ff0],CH` だと0x0ff0部分を機械語に足す
-            auto size = token.GetImmSize() + inst.get_output_size(bit_mode, {token, mnemonic_args[1]});
-            return size;
+            mnemonic_args[0].SetAttribute(TParaToken::ttMem8);
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // C7      m16     imm16
         pattern | ds(TParaToken::ttMem16, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
             // `MOV WORD [addr_size], X`
-            auto addr_size = mnemonic_args[0].GetImmSize();
-            auto size = addr_size + inst.get_output_size(bit_mode, mnemonic_args);
-            return size;
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 89      m16     r16
         pattern | ds(TParaToken::ttMem16, _, TParaToken::ttReg16, _) = [&] {
@@ -1433,11 +1427,7 @@ void Pass1Strategy::processMOV(std::vector<TParaToken>& mnemonic_args) {
         // C7      m32     imm32
         pattern | ds(TParaToken::ttMem32, _, or_(TParaToken::ttImm, TParaToken::ttLabel), _) = [&] {
             // `MOV DWORD [addr_size], X`
-            // TODO: x86 tableの定義に`prefix`の定義がない
-            auto override_prefix_size = (bit_mode != ID_32BIT_MODE) ? 1 : 0;
-            auto addr_size = mnemonic_args[0].GetImmSize();
-            auto size = override_prefix_size + addr_size + inst.get_output_size(bit_mode, mnemonic_args);
-            return size;
+            return inst.get_output_size(bit_mode, mnemonic_args);
         },
         // 89      m32     r32
         pattern | ds(TParaToken::ttMem32, _, TParaToken::ttReg32, _) = [&] {

--- a/src/x86.cc
+++ b/src/x86.cc
@@ -77,6 +77,9 @@ namespace x86_64 {
 
             if (t.IsMem() && t.HasMemBase()) {
                 auto offset = t.AsMem().offset();
+                if (offset == 0) {
+                    continue; // offsetなし
+                }
 
                 if (-0x80 <= offset && offset <= 0x7f) {
                     offset_byte_size += 1;

--- a/src/x86.cc
+++ b/src/x86.cc
@@ -47,6 +47,7 @@ namespace x86_64 {
 
             require = match(mode)(
                 pattern | ID_16BIT_MODE | when(t.AsAttr() == TParaToken::ttReg32) = true,
+                pattern | ID_16BIT_MODE | when(t.AsAttr() == TParaToken::ttMem32) = true,
                 pattern | ID_16BIT_MODE = false,
                 pattern | _ = false
             );
@@ -297,13 +298,15 @@ namespace x86_64 {
             int require_67h = 0;
 
             if (_require_66h(mode, tokens)) {
+                logger->trace("[pass1] bytes 0x66h 1");
                 require_66h = 1;
             }
             if (_require_67h(mode, tokens)) {
+                logger->trace("[pass1] bytes 0x67h 1");
                 require_67h = 1;
             }
             const auto offset_byte_size = _calc_offset_byte_size(tokens); // 直接アドレス表現等で使用されるバイト数計算
-
+            logger->trace("[pass1] bytes offset byte size {}", offset_byte_size);
             logger->debug("[pass1] selected form with minimum machine code size: {}",
                           min_size + require_66h + require_67h + offset_byte_size);
             return min_size + require_66h + require_67h + offset_byte_size;

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -1239,7 +1239,7 @@ bootpack:
     expected.insert(expected.end(), {0x66, 0xbe, 0x30, 0xc3, 0x00, 0x00});
     expected.insert(expected.end(), {0x66, 0xbf, 0x00, 0x00, 0x28, 0x00});
     expected.insert(expected.end(), {0x66, 0xb9, 0x00, 0x00, 0x02, 0x00});
-    expected.insert(expected.end(), {0xe8, 0x60, 0x00});
+    expected.insert(expected.end(), {0xe8, 0x75, 0x00});
 
     // まずはブートセクタから
     expected.insert(expected.end(), {0x66, 0xbe, 0x00, 0x7c, 0x00, 0x00});
@@ -1298,6 +1298,5 @@ bootpack:
     expected.insert(expected.end(), {0x00, 0x00});
 
     // 作成したバイナリの差分assert & diff表示
-    GTEST_SKIP(); // TODO: まだ機能しない
     ASSERT_PRED_FORMAT2(checkTextF, expected, d->binout_container);
 }

--- a/test/exp_suite.cpp
+++ b/test/exp_suite.cpp
@@ -14,7 +14,7 @@ class ExpSuite : public ::testing::Test {
 protected:
     // 試験開始時に一回だけ実行
     ExpSuite() {
-        spdlog::set_level(spdlog::level::debug);
+        spdlog::set_level(spdlog::level::trace);
     }
 
     // 試験終了時に一回だけ実行

--- a/test/inst_suite.cpp
+++ b/test/inst_suite.cpp
@@ -49,7 +49,18 @@ struct StatementToMachineCodeParam {
 };
 
 void PrintTo(const StatementToMachineCodeParam& param, ::std::ostream* os) {
-    *os << param._statement;
+
+    // テストケース名のspaceとカンマは「_」にしたい
+    std::string case_name = param._statement;
+    for (char& c : case_name) {
+        if (c == ' ' || c == ',') {
+            c = '_';
+        }
+        if (c == '[' || c == ']') {
+            c = '/';
+        }
+    }
+    *os << case_name;
 }
 
 class StatementToMachineCode : public testing::TestWithParam<StatementToMachineCodeParam> {

--- a/test/pass1_test.cpp
+++ b/test/pass1_test.cpp
@@ -324,7 +324,6 @@ bootpack:
     // 0xc200=49664
     EXPECT_EQ(0xc200 + 87,  pass1->sym_table["pipelineflush"]);
     EXPECT_EQ(0xc200 + 218, pass1->sym_table["skip"]);
-    GTEST_SKIP(); // TODO: まだ機能しない
     EXPECT_EQ(0xc200 + 231, pass1->sym_table["waitkbdout"]);
     EXPECT_EQ(0xc200 + 238, pass1->sym_table["memcpy"]);
     EXPECT_EQ(0xc200 + 272, pass1->sym_table["GDT0"]);

--- a/test/pass1_test.cpp
+++ b/test/pass1_test.cpp
@@ -323,11 +323,11 @@ bootpack:
 
     // 0xc200=49664
     EXPECT_EQ(0xc200 + 87,  pass1->sym_table["pipelineflush"]);
+    EXPECT_EQ(0xc200 + 218, pass1->sym_table["skip"]);
     GTEST_SKIP(); // TODO: まだ機能しない
-    EXPECT_EQ(0xc200 + 217, pass1->sym_table["skip"]);
-    EXPECT_EQ(0xc200 + 230, pass1->sym_table["waitkbdout"]);
-    EXPECT_EQ(0xc200 + 237, pass1->sym_table["memcpy"]);
-    EXPECT_EQ(0xc200 + 271, pass1->sym_table["GDT0"]);
-    EXPECT_EQ(0xc200 + 297, pass1->sym_table["GDTR0"]);
-    EXPECT_EQ(0xc200 + 303, pass1->sym_table["bootpack"]);
+    EXPECT_EQ(0xc200 + 231, pass1->sym_table["waitkbdout"]);
+    EXPECT_EQ(0xc200 + 238, pass1->sym_table["memcpy"]);
+    EXPECT_EQ(0xc200 + 272, pass1->sym_table["GDT0"]);
+    EXPECT_EQ(0xc200 + 298, pass1->sym_table["GDTR0"]);
+    EXPECT_EQ(0xc200 + 304, pass1->sym_table["bootpack"]);
 }

--- a/test/x86_table_test.cpp
+++ b/test/x86_table_test.cpp
@@ -8,6 +8,7 @@
 using namespace x86_64;
 using namespace jsoncons;
 
+
 class X86TableSuite : public ::testing::Test {
 
 protected:
@@ -65,7 +66,9 @@ TEST_F(X86TableSuite, CheckJsonSchema)
     }
 }
 
+//
 // トークン読み取りパラメタライズテスト
+//
 struct TokenToX86TypeParam {
     const std::string token;
     const TParaToken para_token;
@@ -109,10 +112,9 @@ INSTANTIATE_TEST_SUITE_P(X86TableSuite, TokenToX86Type,
     )
 );
 
-// ---
-
-
+//
 // 命令ごとの機械語サイズ取得パラメタライズテスト
+//
 struct InstToMachineCodeSizeParam {
 
     // ここからはパラメーター
@@ -136,7 +138,14 @@ struct InstToMachineCodeSizeParam {
 };
 
 void PrintTo(const InstToMachineCodeSizeParam& param, ::std::ostream* os) {
-    *os << param._opcode;
+    *os << param._opcode << "_";
+    for (int i = 0; i < param._tokens.size(); i++ ) {
+        auto t = param._tokens[i];
+        *os << t.AsString();
+        if (i != param._tokens.size() - 1) {
+            *os << "_";
+        }
+    }
 }
 
 class InstToMachineCodeSize : public testing::TestWithParam<InstToMachineCodeSizeParam> {
@@ -188,7 +197,7 @@ INSTANTIATE_TEST_SUITE_P(X86TableSuite, InstToMachineCodeSize,
     testing::Values(
         InstToMachineCodeSizeParam(ID_16BIT_MODE, "ADD",
                                    {
-                                       TParaToken("[BX]", TParaToken::ttIdentifier, TParaToken::ttMem16),
+                                       TParaToken("[BX]", TParaToken::ttIdentifier, TParaToken::ttMem16).SetMem(asmjit::x86::ptr(asmjit::x86::bx)),
                                        TParaToken("AX", TParaToken::ttIdentifier, TParaToken::ttReg16)
                                    },
                                    2),
@@ -205,7 +214,7 @@ INSTANTIATE_TEST_SUITE_P(X86TableSuite, InstToMachineCodeSize,
         InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
                                    {
                                        TParaToken("AL", TParaToken::ttIdentifier, TParaToken::ttReg8),
-                                       TParaToken("SI", TParaToken::ttIdentifier, TParaToken::ttMem8)
+                                       TParaToken("[SI]", TParaToken::ttIdentifier, TParaToken::ttMem8).SetMem(asmjit::x86::ptr(asmjit::x86::si))
                                    },
                                    2),
         InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
@@ -214,12 +223,16 @@ INSTANTIATE_TEST_SUITE_P(X86TableSuite, InstToMachineCodeSize,
                                        TParaToken("0", TParaToken::ttInteger, TParaToken::ttImm)
                                    },
                                    3),
+        // 0x8A, 0x0E, 0xF00F = 4byte
+        // 通常の機械語サイズにメモリーアドレス表現で示されるオフセット部分のサイズを足す
         InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
                                    {
-                                       TParaToken("[0x0ff0]", TParaToken::ttHex, TParaToken::ttMem8),
-                                       TParaToken("CH", TParaToken::ttIdentifier, TParaToken::ttReg8)
+                                       TParaToken("CL", TParaToken::ttIdentifier, TParaToken::ttReg8),
+                                       TParaToken("0x0ff0", TParaToken::ttHex, TParaToken::ttMem8)
+                                       // ↑本来 BYTE [0x0ff0] と設定されるが単体テスト上こうなる
+                                       // parseされる中でtokenがこの値を保持するようになる
                                    },
-                                   2), // +2byteはpass1側で足す
+                                   4),
         // 0x0D id    = 1(prefix) + 1 + 4 byte     = 6byte
         // 0x83 /1 ib = 1(prefix) + 1 + 1 + 1 byte = 4byte
         // 出力される機械語が少ない方を優先的に選ぶ

--- a/test/x86_table_test.cpp
+++ b/test/x86_table_test.cpp
@@ -278,6 +278,20 @@ INSTANTIATE_TEST_SUITE_P(X86TableSuite, InstToMachineCodeSize,
                                        TParaToken("0x0ff0", TParaToken::ttHex, TParaToken::ttMem8),
                                        TParaToken("CH", TParaToken::ttIdentifier, TParaToken::ttReg8)
                                    },
-                                   4)
+                                   4),
+        // 0x66, 0x81, 0xe9, 0x80, 0x00, 0x00, 0x00
+        InstToMachineCodeSizeParam(ID_16BIT_MODE, "SUB",
+                                   {
+                                       TParaToken("ECX", TParaToken::ttIdentifier, TParaToken::ttReg32),
+                                       TParaToken("128", TParaToken::ttInteger, TParaToken::ttImm)
+                                   },
+                                   7),
+        // 0x67, 0x66, 0x8b, 0x4b, 0x10
+        InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
+                                   {
+                                       TParaToken("ECX", TParaToken::ttIdentifier, TParaToken::ttReg32),
+                                       TParaToken("EBX", TParaToken::ttIdentifier, TParaToken::ttMem32).SetMem(asmjit::x86::ptr(asmjit::x86::ebx, 16))
+                                   },
+                                   5)
     )
 );

--- a/test/x86_table_test.cpp
+++ b/test/x86_table_test.cpp
@@ -223,6 +223,27 @@ INSTANTIATE_TEST_SUITE_P(X86TableSuite, InstToMachineCodeSize,
                                        TParaToken("0", TParaToken::ttInteger, TParaToken::ttImm)
                                    },
                                    3),
+        // 0xc6, 0x06, 0xf2, 0x0f, 0x08
+        InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
+                                   {
+                                       TParaToken("0x0ff2", TParaToken::ttHex, TParaToken::ttMem8),
+                                       TParaToken("8", TParaToken::ttInteger, TParaToken::ttImm)
+                                   },
+                                   5),
+        // 0xc7, 0x06, 0xf4, 0x0f, 0x40, 0x01
+        InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
+                                   {
+                                       TParaToken("0x0ff4", TParaToken::ttHex, TParaToken::ttMem16),
+                                       TParaToken("320", TParaToken::ttInteger, TParaToken::ttImm)
+                                   },
+                                   6),
+        // 0x66, 0xc7, 0x06, 0xf8, 0x0f, 0x00, 0x00, 0x0a, 0x00
+        InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
+                                   {
+                                       TParaToken("0x0ff8", TParaToken::ttHex, TParaToken::ttMem32),
+                                       TParaToken("0x000a0000", TParaToken::ttHex, TParaToken::ttImm)
+                                   },
+                                   9),
         // 0x8A, 0x0E, 0xF00F = 4byte
         // 通常の機械語サイズにメモリーアドレス表現で示されるオフセット部分のサイズを足す
         InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
@@ -247,6 +268,16 @@ INSTANTIATE_TEST_SUITE_P(X86TableSuite, InstToMachineCodeSize,
                                        TParaToken("ECX", TParaToken::ttIdentifier, TParaToken::ttReg32),
                                        TParaToken("4608", TParaToken::ttInteger, TParaToken::ttImm)
                                    },
-                                   7)
+                                   7),
+        // 0x88,0x2e,0xf0,0x0f
+        InstToMachineCodeSizeParam(ID_16BIT_MODE, "MOV",
+                                   {
+                                       // pass1でttMem16->ttMem8に変換される
+                                       // 本来 BYTE [0x0ff0] と設定されるが単体テスト上こうなる
+                                       // parseされる中でtokenがこの値を保持するようになる
+                                       TParaToken("0x0ff0", TParaToken::ttHex, TParaToken::ttMem8),
+                                       TParaToken("CH", TParaToken::ttIdentifier, TParaToken::ttReg8)
+                                   },
+                                   4)
     )
 );


### PR DESCRIPTION
ref #85

## 対応内容
- ３日目の実装(harib00i) やっと完了
    - [３日目のアセンブラをダンプ（後編）](https://github.com/HobbyOSs/opennask/wiki/%EF%BC%93%E6%97%A5%E7%9B%AE%E3%81%AE%E3%82%A2%E3%82%BB%E3%83%B3%E3%83%96%E3%83%A9%E3%82%92%E3%83%80%E3%83%B3%E3%83%97%EF%BC%88%E5%BE%8C%E7%B7%A8%EF%BC%89)


## やったこと
- ジャンプ系の命令の機械語サイズ計算処理を主に追加/修正