### PR TITLE
EBNF版のnask_parseで実装を置き換え(5)

### DIFF
--- a/src/front_end.hh
+++ b/src/front_end.hh
@@ -16,6 +16,7 @@
 #include "skeleton.hh"
 #include "bin_util.hh"
 #include "pass1_strategy.hh"
+#include "object_file_writer.hh"
 
 class FrontEnd : public Skeleton, public BinUtil {
 
@@ -32,6 +33,9 @@ private:
     asmjit::Environment env_;
     asmjit::CodeHolder code_;
     std::unique_ptr<asmjit::x86::Assembler> a_;
+
+    // coff/elf...
+    std::unique_ptr<ObjectFileWriter> o_writer_;
 
 public:
     // visitorのcontext情報

--- a/src/front_end/front_config.cc
+++ b/src/front_end/front_config.cc
@@ -9,6 +9,15 @@
 using namespace std::placeholders;
 using namespace matchit;
 
+void FrontEnd::visitExportSymStmt(ExportSymStmt *export_sym_stmt) {
+
+    if (export_sym_stmt->factor_) export_sym_stmt->factor_->accept(this);
+    TParaToken symbol = this->ctx.top();
+    o_writer_->add_global_symbol(symbol.AsString());
+    this->ctx.pop();
+
+    log()->debug("[pass2] symbol {}", symbol.AsString());
+}
 
 void FrontEnd::visitConfigStmt(ConfigStmt *config_stmt) {
 

--- a/src/front_end/front_config.cc
+++ b/src/front_end/front_config.cc
@@ -31,6 +31,10 @@ void FrontEnd::visitConfigStmt(ConfigStmt *config_stmt) {
         pattern | "FormConfig" | when (t.AsString() == "WCOFF") = [&] {
             o_writer_ = std::make_unique<ObjectFileWriter>();
         },
+        pattern | "FileConfig" = [&] {
+            auto file_name = t.AsString();
+            o_writer_->set_file_name(file_name);
+        },
         pattern | "InstConfig" = [&] {
             // NOP
         },

--- a/src/front_end/front_config.cc
+++ b/src/front_end/front_config.cc
@@ -29,8 +29,7 @@ void FrontEnd::visitConfigStmt(ConfigStmt *config_stmt) {
             throw std::runtime_error("Invalid bit_mode: " + t.AsString());
         },
         pattern | "FormConfig" | when (t.AsString() == "WCOFF") = [&] {
-            auto writer = std::make_unique<ObjectFileWriter>();
-            writer->write_coff(*a_);
+            o_writer_ = std::make_unique<ObjectFileWriter>();
         },
         pattern | "InstConfig" = [&] {
             // NOP

--- a/src/front_end/front_config.cc
+++ b/src/front_end/front_config.cc
@@ -38,11 +38,14 @@ void FrontEnd::visitConfigStmt(ConfigStmt *config_stmt) {
             throw std::runtime_error("Invalid bit_mode: " + t.AsString());
         },
         pattern | "FormConfig" | when (t.AsString() == "WCOFF") = [&] {
-            o_writer_ = std::make_unique<ObjectFileWriter>();
+            o_writer_ = std::make_unique<ObjectFileWriter>(); // TODO: ELFも出したい場合ObjectFileWriterのIFを作って内部で分岐
         },
         pattern | "FileConfig" = [&] {
             auto file_name = t.AsString();
             o_writer_->set_file_name(file_name);
+        },
+        pattern | "SectConfig" = [&] {
+            // TODO: [SECTION .text] 以外の処理にも対応する(?) しかしその場合BNFの構文自体変えたほうが良さそうである
         },
         pattern | "InstConfig" = [&] {
             // NOP

--- a/src/front_end/front_parse.cc
+++ b/src/front_end/front_parse.cc
@@ -166,15 +166,6 @@ void FrontEnd::visitDeclareStmt(DeclareStmt *declare_stmt) {
     equ_map[key.AsString()] = value;
 }
 
-void FrontEnd::visitExportSymStmt(ExportSymStmt *export_sym_stmt) {
-
-    if (export_sym_stmt->factor_) export_sym_stmt->factor_->accept(this);
-    TParaToken symbol = this->ctx.top();
-    this->ctx.pop();
-
-    log()->debug("[pass2] symbol {}", symbol.AsString());
-}
-
 void FrontEnd::visitMnemonicStmt(MnemonicStmt *mnemonic_stmt){
 
     if (mnemonic_stmt->opcode_) {

--- a/src/front_end/front_parse.cc
+++ b/src/front_end/front_parse.cc
@@ -29,11 +29,15 @@ FrontEnd::FrontEnd(bool trace_scanning, bool trace_parsing) {
     dollar_position = 0;
     equ_map = std::map<std::string, TParaToken>{};
 
+    // asmjit
     using namespace asmjit;
     Environment env;
     env.setArch(Arch::kX86);
     code_.init(env);
     a_ = std::make_unique<x86::Assembler>(&code_);
+
+    // coff, elf
+    o_writer_ = nullptr;
 }
 
 FrontEnd::~FrontEnd() {
@@ -574,8 +578,8 @@ template std::shared_ptr<Opcode> FrontEnd::Parse<Opcode>(std::istream &input);
 template <class T>
 int FrontEnd::Eval(T *parse_tree, const char* assembly_dst) {
 
-    std::ofstream binout(assembly_dst, std::ios::trunc | std::ios::binary);
-    if ( binout.bad() || binout.fail() ) {
+    std::ofstream img_out(assembly_dst, std::ios::trunc | std::ios::binary);
+    if ( img_out.bad() || img_out.fail() ) {
         std::cerr << "NASK : can't open " << assembly_dst << std::endl;
         return 17;
     }
@@ -620,13 +624,15 @@ int FrontEnd::Eval(T *parse_tree, const char* assembly_dst) {
 
     using namespace asmjit;
     CodeBuffer& buf = code_.textSection()->buffer();
-    // TODO: 互換性のため、しばらくこのようにしてbinout_containerを
-    // 使えるようにしておく
+
+    if (o_writer_ != nullptr) {
+        // オブジェクトファイル書き出しモード
+        o_writer_->write_coff(code_, *a_);
+    }
     binout_container.assign(buf.data(), buf.data() + buf.size());
-    binout.write(reinterpret_cast<char*>(binout_container.data()),
-                 binout_container.size());
-    //binout.write(reinterpret_cast<char*>(buf.data()), buf.size());
-    binout.close();
+
+    img_out.write(reinterpret_cast<char*>(binout_container.data()), binout_container.size());
+    img_out.close();
 
     return 0;
 }

--- a/src/front_end_ext.hh
+++ b/src/front_end_ext.hh
@@ -28,6 +28,11 @@ void FrontEnd::with_asmjit(F && f) {
 
     f(*a_, pp);
 
+    const size_t after_size = buf.size();
+    if (before_size == after_size) {
+        return; // 何も出力がないときはskip
+    }
+
     // asmjitはデフォルトは32bitモード
     // 0x67, 0x66の制御
     std::vector<uint8_t> old_data(buf.data(), buf.data() + buf.size());

--- a/src/object_file_writer.cc
+++ b/src/object_file_writer.cc
@@ -21,12 +21,27 @@ ObjectFileWriter::ObjectFileWriter() {
 void ObjectFileWriter::set_file_name(std::string& file_name) {
     // coffiでは`auxiliary_symbol_record_4` で定義される
     // https://coffi.readthedocs.io/en/latest/annotated.html
+    // ちょっとしつこいコメントになるが設定値の意味も付記する
     symbol* sym1 = writer_->add_symbol(".file");
+    // IMAGE_SYM_DEBUG
+    // The symbol provides general type or debugging information but does not correspond to a section.
+    // Microsoft tools use this setting along with .file records (storage class FILE).
+    sym1->set_section_number(IMAGE_SYM_DEBUG);
+
+    // IMAGE_SYM_CLASS_FILE
+    // Used by Microsoft tools, as well as traditional COFF format, for the source-file symbol record.
+    // The symbol is followed by auxiliary records that name the file.
+    sym1->set_storage_class(IMAGE_SYM_CLASS_FILE);
+    // シンボルはこの中では1つしかないので1
+    sym1->set_aux_symbols_number(1);
+
     auxiliary_symbol_record_4 record;
-    std::strncpy(record.file_name, file_name.c_str(), sizeof(record.file_name) - 2);
+    std::strncpy(record.file_name, file_name.c_str(), sizeof(record.file_name));
     for (size_t i = file_name.size(); i < sizeof(record.file_name) - 1; i++) {
         record.file_name[i] = '\0';
     }
+    record.file_name[sizeof(record.file_name) - 1] = '\0'; // 末尾を0で埋める
+
     sym1->get_auxiliary_symbols().push_back(*(auxiliary_symbol_record*)&record);
 }
 
@@ -36,17 +51,6 @@ void ObjectFileWriter::write_coff(asmjit::CodeHolder& code_, asmjit::x86::Assemb
 
     // .textに最終的な機械語を差し込む
     section* text = writer_->add_section(".text");
-    //char text[] = {
-    //    '\x55',                                 // push   %ebp
-    //    '\x89', '\xE5',                         // mov    %esp,%ebp
-    //    '\x83', '\xE4', '\xF0',                 // and    $0xfffffff0,%esp
-    //    '\xE8', '\x00', '\x00', '\x00', '\x00', // call   b <_main+0xb>
-    //    '\xB8', '\x2A', '\x00', '\x00', '\x00', // mov    $0x2a,%eax
-    //    '\xC9',                                 // leave
-    //    '\xC3',                                 // ret
-    //    '\x90',                                 // nop
-    //    '\x90',                                 // nop
-    //};
     text->set_data(reinterpret_cast<const char*>(buf.data()), buf.size());
     section* data = writer_->add_section(".data");
     section* bss = writer_->add_section(".bss");

--- a/src/object_file_writer.cc
+++ b/src/object_file_writer.cc
@@ -52,8 +52,20 @@ void ObjectFileWriter::write_coff(asmjit::CodeHolder& code_, asmjit::x86::Assemb
     // .textに最終的な機械語を差し込む
     section* text = writer_->add_section(".text");
     text->set_data(reinterpret_cast<const char*>(buf.data()), buf.size());
+    text->set_flags(IMAGE_SCN_CNT_CODE    | // The section contains executable code
+                    IMAGE_SCN_MEM_READ    |
+                    IMAGE_SCN_MEM_EXECUTE |
+                    IMAGE_SCN_ALIGN_1BYTES);
     section* data = writer_->add_section(".data");
+    data->set_flags(IMAGE_SCN_CNT_INITIALIZED_DATA | // The section contains initialized data.
+                    IMAGE_SCN_MEM_WRITE            |
+                    IMAGE_SCN_MEM_READ             |
+                    IMAGE_SCN_ALIGN_1BYTES);
     section* bss = writer_->add_section(".bss");
+    bss->set_flags(IMAGE_SCN_CNT_UNINITIALIZED_DATA | // The section contains uninitialized data.
+                   IMAGE_SCN_MEM_WRITE              |
+                   IMAGE_SCN_MEM_READ               |
+                   IMAGE_SCN_ALIGN_1BYTES);
 
     // WCOFFを出力する
     std::ostringstream oss;

--- a/src/object_file_writer.cc
+++ b/src/object_file_writer.cc
@@ -19,7 +19,15 @@ ObjectFileWriter::ObjectFileWriter() {
 
 
 void ObjectFileWriter::set_file_name(std::string& file_name) {
-    //writer->();
+    // coffiでは`auxiliary_symbol_record_4` で定義される
+    // https://coffi.readthedocs.io/en/latest/annotated.html
+    symbol* sym1 = writer_->add_symbol(".file");
+    auxiliary_symbol_record_4 record;
+    std::strncpy(record.file_name, file_name.c_str(), sizeof(record.file_name) - 2);
+    for (size_t i = file_name.size(); i < sizeof(record.file_name) - 1; i++) {
+        record.file_name[i] = '\0';
+    }
+    sym1->get_auxiliary_symbols().push_back(*(auxiliary_symbol_record*)&record);
 }
 
 void ObjectFileWriter::write_coff(asmjit::CodeHolder& code_, asmjit::x86::Assembler& a) {

--- a/src/object_file_writer.cc
+++ b/src/object_file_writer.cc
@@ -49,9 +49,10 @@ void ObjectFileWriter::write_coff(asmjit::CodeHolder& code_, asmjit::x86::Assemb
 
     CodeBuffer& buf = code_.textSection()->buffer();
 
-    // .textに最終的な機械語を差し込む
+    /**
+     * section header
+     */
     section* text = writer_->add_section(".text");
-    text->set_data(reinterpret_cast<const char*>(buf.data()), buf.size());
     text->set_flags(IMAGE_SCN_CNT_CODE    | // The section contains executable code
                     IMAGE_SCN_MEM_READ    |
                     IMAGE_SCN_MEM_EXECUTE |
@@ -61,17 +62,35 @@ void ObjectFileWriter::write_coff(asmjit::CodeHolder& code_, asmjit::x86::Assemb
                     IMAGE_SCN_MEM_WRITE            |
                     IMAGE_SCN_MEM_READ             |
                     IMAGE_SCN_ALIGN_1BYTES);
+    //const char empty_data[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00};
+    //data->set_data(empty_data, sizeof(empty_data));
+
     section* bss = writer_->add_section(".bss");
     bss->set_flags(IMAGE_SCN_CNT_UNINITIALIZED_DATA | // The section contains uninitialized data.
                    IMAGE_SCN_MEM_WRITE              |
                    IMAGE_SCN_MEM_READ               |
                    IMAGE_SCN_ALIGN_1BYTES);
+    // .bssに最終的な機械語を差し込む
+    bss->set_data(reinterpret_cast<const char*>(buf.data()), buf.size());
+
+    symbol* sym_text = writer_->add_symbol(".text");
+    sym_text->set_type(IMAGE_SYM_TYPE_NOT_FUNCTION);
+    sym_text->set_storage_class(IMAGE_SYM_CLASS_STATIC);
+    sym_text->set_section_number(1);
+    sym_text->set_aux_symbols_number(1);
+
+    symbol* sym_data = writer_->add_symbol(".data");
+    sym_data->set_type(IMAGE_SYM_TYPE_NOT_FUNCTION);
+    sym_data->set_storage_class(IMAGE_SYM_CLASS_STATIC);
+    sym_data->set_section_number(2);
+    sym_data->set_aux_symbols_number(1);
 
     // WCOFFを出力する
     std::ostringstream oss;
     writer_->save(oss);
     std::string hex_dump = oss.str();
 
+    // debug用
     for (int i = 0; i < hex_dump.size(); i++) {
         if (i % 16 == 0) {
             std::cout << std::endl;
@@ -84,5 +103,10 @@ void ObjectFileWriter::write_coff(asmjit::CodeHolder& code_, asmjit::x86::Assemb
     }
     std::cout << std::dec << std::endl; // 16進数表示を元に戻す
 
-    a.embed(hex_dump.c_str(), hex_dump.size());
+
+    // もともとasmjitのバッファに書き込まれているデータをリセットして上書きする
+    memset(buf._data, 0, buf.size());
+    memcpy(buf.begin(), hex_dump.c_str(), hex_dump.size());
+    buf._size = hex_dump.size();
+    a._bufferPtr = buf.data() + hex_dump.size(); // asmjit/src/asmjit/core/assembler.h L.40
 };

--- a/src/object_file_writer.hh
+++ b/src/object_file_writer.hh
@@ -2,12 +2,17 @@
 #define OBJECT_FILE_WRITER_HH
 
 #include <asmjit/asmjit.h>
+#include <coffi/coffi.hpp>
 #include "nask_defs.hpp"
 
 class ObjectFileWriter {
 
 public:
-    void write_coff(asmjit::x86::Assembler&);
+    std::unique_ptr<COFFI::coffi> writer_;
+    ObjectFileWriter();
+
+    void set_file_name(std::string&);
+    void write_coff(asmjit::CodeHolder&, asmjit::x86::Assembler&);
 };
 
 #endif // ! OBJECT_FILE_WRITER_HH

--- a/src/object_file_writer.hh
+++ b/src/object_file_writer.hh
@@ -7,11 +7,17 @@
 
 class ObjectFileWriter {
 
+    std::vector<std::string> global_symbol_list;
+    std::vector<std::string> extern_symbol_list;
+
 public:
     std::unique_ptr<COFFI::coffi> writer_;
     ObjectFileWriter();
+    ~ObjectFileWriter();
 
-    void set_file_name(std::string&);
+    void set_file_name(const std::string&);
+    void add_global_symbol(const std::string&);
+    void add_extern_symbol(const std::string&);
     void write_coff(asmjit::CodeHolder&, asmjit::x86::Assembler&);
 };
 

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -1317,14 +1317,14 @@ TEST_F(Day03Suite, Harib00j) {
 
 [FILE "naskfunc.nas"]			; ソースファイル名情報
 
-;		GLOBAL	_io_hlt			; このプログラムに含まれる関数名
+		GLOBAL	_io_hlt			; このプログラムに含まれる関数名
 
 
 ; 以下は実際の関数
 
 ;[SECTION .text]		; オブジェクトファイルではこれを書いてからプログラムを書く
-;
-;_io_hlt:	; void io_hlt(void);
+
+_io_hlt:	; void io_hlt(void);
     	HLT
     	RET
 )";

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -1322,7 +1322,7 @@ TEST_F(Day03Suite, Harib00j) {
 
 ; 以下は実際の関数
 
-;[SECTION .text]		; オブジェクトファイルではこれを書いてからプログラムを書く
+[SECTION .text]		; オブジェクトファイルではこれを書いてからプログラムを書く
 
 _io_hlt:	; void io_hlt(void);
     	HLT

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -1315,7 +1315,7 @@ TEST_F(Day03Suite, Harib00j) {
 
 ; オブジェクトファイルのための情報
 
-;[FILE "naskfunc.nas"]			; ソースファイル名情報
+[FILE "naskfunc.nas"]			; ソースファイル名情報
 
 ;		GLOBAL	_io_hlt			; このプログラムに含まれる関数名
 

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -1325,8 +1325,8 @@ TEST_F(Day03Suite, Harib00j) {
 ;[SECTION .text]		; オブジェクトファイルではこれを書いてからプログラムを書く
 ;
 ;_io_hlt:	; void io_hlt(void);
-;    	HLT
-;    	RET
+    	HLT
+    	RET
 )";
 
     // od形式で出力する際は `od -t x1 test/test.img > test_img.txt`

--- a/test/day03test.cpp
+++ b/test/day03test.cpp
@@ -1347,7 +1347,6 @@ TEST_F(Day03Suite, Harib00j) {
             0x00, 0x00,             // sizeOfOptionalHeader
             0x00, 0x00              // flags
         });
-    /**
     // COFFの各種section
     expected.insert(expected.end(), {
             0x2e, 0x74, 0x65, 0x78, 0x74, 0x00, 0x00, 0x00, // .text
@@ -1413,9 +1412,7 @@ TEST_F(Day03Suite, Harib00j) {
             0x5f, 0x69, 0x6f, 0x5f, 0x68, 0x6c, 0x74, 0x00, // シンボル情報
             0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
             0x02, 0x00, 0x04, 0x00, 0x00, 0x00 });
-    */
 
     // 作成したバイナリの差分assert & diff表示
-    GTEST_SKIP(); // 差分を実装中
     ASSERT_PRED_FORMAT2(checkTextF, expected, d->binout_container);
 }


### PR DESCRIPTION
ref #85

## 対応内容
- ３日目の実装(harib00j) が完了(WCOFFの出力)
    - [３日目 harib00jのコンパイル](https://github.com/HobbyOSs/opennask/wiki/%EF%BC%93%E6%97%A5%E7%9B%AE-harib00j%E3%81%AE%E3%82%B3%E3%83%B3%E3%83%91%E3%82%A4%E3%83%AB)

## やったこと
- COFFIを導入してCOFF形式ファイルの書き出しの実装
- naskでは `[FORMAT "WCOFF"]` を指定するとオブジェクトファイルを作るモードとなる。FORMATディレクティブが指定された場合とそうでない場合でファイル出力時の動作の切り替えをするようにしている

## 備考
- もともと自分の実装でかなりぐちゃっとした部分だったが、前よりきれいに書けたと思う（それはオフセットの計算をCOFFIにまかせているためである）

https://github.com/HobbyOSs/opennask/blob/master/src/bracket_impl.hpp

- `[SECTION .text]` 以外の処理にも対応するべきなのかどうか…そもそもアセンブラでそういうことしたい？